### PR TITLE
feat: add rule system extensibility hooks

### DIFF
--- a/src/chat/ChatInput.tsx
+++ b/src/chat/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useMemo } from 'react'
 import { rollCompound, resolveFormula } from '../shared/diceUtils'
 import type { ChatMessage } from './chatTypes'
+import type { ChatCommand } from '../rules/types'
 
 interface Suggestion {
   key: string
@@ -18,6 +19,7 @@ interface ChatInputProps {
   onSend: (message: ChatMessage) => void
   onFocus?: () => void
   onCycleSpeaker?: () => void
+  customCommands?: ChatCommand[]
 }
 
 function generateId(): string {
@@ -36,6 +38,7 @@ export function ChatInput({
   onSend,
   onFocus,
   onCycleSpeaker,
+  customCommands = [],
 }: ChatInputProps) {
   const [input, setInput] = useState('')
   const [error, setError] = useState('')
@@ -100,6 +103,17 @@ export function ChatInput({
     const trimmed = input.trim()
     if (!trimmed) return
 
+    // Check custom commands from rule system (e.g. ".dd")
+    for (const cmd of customCommands) {
+      const re = new RegExp(`^\\${cmd.prefix}\\s*(.*)$`, 'i')
+      const match = trimmed.match(re)
+      if (match) {
+        const formula = cmd.buildFormula(match[1].trim())
+        handleRoll(formula, cmd.name)
+        return
+      }
+    }
+
     // Check if it's a dice roll
     const rollMatch = trimmed.match(/^\.r\s*(.+)$/i)
     if (rollMatch) {
@@ -122,7 +136,7 @@ export function ChatInput({
     }
   }
 
-  const handleRoll = (formula: string) => {
+  const handleRoll = (formula: string, actionName?: string) => {
     // Resolve @key references using provided token props
     const tokenProps = selectedTokenProps
 
@@ -162,6 +176,7 @@ export function ChatInput({
       terms: result.termResults,
       total: result.total,
       timestamp: Date.now(),
+      actionName,
     })
     setInput('')
     setError('')

--- a/src/chat/ChatPanel.tsx
+++ b/src/chat/ChatPanel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import * as Y from 'yjs'
-import type { ChatMessage } from './chatTypes'
+import type { ChatMessage, ChatRollMessage } from './chatTypes'
 import type { Entity } from '../shared/entityTypes'
+import type { RuleSystem } from '../rules/types'
 import { getEntityResources, getEntityAttributes } from '../shared/entityAdapters'
 import { MessageScrollArea } from './MessageScrollArea'
 import { ToastStack, type ToastItem } from './ToastStack'
@@ -17,6 +18,7 @@ interface ChatPanelProps {
   seatProperties: { key: string; value: string }[]
   selectedTokenProps?: { key: string; value: string }[]
   speakerEntities: Entity[]
+  ruleSystem?: RuleSystem
 }
 
 /** Resolved identity used for sending messages */
@@ -88,6 +90,7 @@ export function ChatPanel({
   seatProperties,
   selectedTokenProps = [],
   speakerEntities,
+  ruleSystem,
 }: ChatPanelProps) {
   const [expanded, setExpanded] = useState(false)
   const [messages, setMessages] = useState<ChatMessage[]>([])
@@ -227,9 +230,24 @@ export function ChatPanel({
 
   const handleSend = useCallback(
     (message: ChatMessage) => {
+      // Enrich named roll commands (e.g. .dd) with rule system judgment
+      if (message.type === 'roll' && ruleSystem && message.actionName) {
+        const rollMsg = message as ChatRollMessage
+        if (!rollMsg.judgment) {
+          const judgment = ruleSystem.evaluateRoll(rollMsg.terms, rollMsg.total, {
+            activeModifierIds: [],
+            tempModifier: 0,
+          })
+          if (judgment) {
+            rollMsg.judgment = judgment
+            rollMsg.dieStyles = ruleSystem.getDieStyles(rollMsg.terms)
+            rollMsg.judgmentDisplay = ruleSystem.getJudgmentDisplay(judgment)
+          }
+        }
+      }
       yChat.push([message])
     },
-    [yChat],
+    [yChat, ruleSystem],
   )
 
   // Tab to cycle speaker: seat → entity1 → entity2 → ... → seat
@@ -394,6 +412,7 @@ export function ChatPanel({
             selectedTokenProps={selectedTokenProps}
             seatProperties={activeSpeakerProps}
             onCycleSpeaker={speakerEntities.length > 0 ? handleCycleSpeaker : undefined}
+            customCommands={ruleSystem?.getChatCommands()}
           />
         </div>
       </div>

--- a/src/chat/DiceReel.tsx
+++ b/src/chat/DiceReel.tsx
@@ -9,6 +9,10 @@ interface DiceReelProps {
   dropped?: boolean
   /** Delay (seconds) before showing dropped styling — wait for all dice to land */
   dropRevealDelay?: number
+  /** Override border/glow color (e.g. Hope=gold, Fear=purple) */
+  color?: string
+  /** Tiny label below the die (e.g. "Hope", "Fear") */
+  label?: string
 }
 
 type Phase = 'spinning' | 'landing' | 'stopped'
@@ -19,6 +23,8 @@ export function DiceReel({
   stopDelay,
   dropped = false,
   dropRevealDelay,
+  color,
+  label,
 }: DiceReelProps) {
   // Lock animation params at mount — immune to later prop changes (e.g. isNew toggling)
   const initialRef = useRef({ stopDelay, result, sides, dropRevealDelay })
@@ -78,6 +84,9 @@ export function DiceReel({
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const borderColor = color ? `${color}4D` : 'rgba(96, 165, 250, 0.3)'
+  const glowColor = color ?? 'rgba(59, 130, 246, 1)'
+
   const baseStyle: React.CSSProperties = {
     display: 'inline-flex',
     alignItems: 'center',
@@ -87,7 +96,7 @@ export function DiceReel({
     padding: '0 8px',
     borderRadius: 6,
     background: 'rgba(30, 41, 59, 0.6)',
-    border: '1px solid rgba(96, 165, 250, 0.3)',
+    border: `1px solid ${borderColor}`,
     color: '#e2e8f0',
     fontSize: 16,
     fontWeight: 600,
@@ -102,16 +111,43 @@ export function DiceReel({
     spinning: {
       ...baseStyle,
       filter: 'blur(1.5px)',
-      boxShadow: '0 0 16px rgba(59, 130, 246, 0.5)',
+      boxShadow: `0 0 16px ${glowColor}80`,
     },
     landing: {
       ...baseStyle,
       filter: 'blur(0)',
       animation: 'diceLand 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)',
-      boxShadow: '0 0 20px rgba(59, 130, 246, 0.8), inset 0 0 8px rgba(96, 165, 250, 0.3)',
+      boxShadow: `0 0 20px ${glowColor}CC, inset 0 0 8px ${glowColor}4D`,
     },
     stopped: baseStyle,
   }
 
-  return <span style={phaseStyles[phase]}>{displayValue}</span>
+  const dieEl = <span style={phaseStyles[phase]}>{displayValue}</span>
+
+  if (!label) return dieEl
+
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+      }}
+    >
+      {dieEl}
+      <span
+        style={{
+          fontSize: 8,
+          color: color ?? '#94a3b8',
+          fontWeight: 600,
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+          lineHeight: 1,
+        }}
+      >
+        {label}
+      </span>
+    </span>
+  )
 }

--- a/src/chat/DiceResultCard.tsx
+++ b/src/chat/DiceResultCard.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import type { ChatRollMessage } from './chatTypes'
+import type { DieStyle } from '../rules/types'
 import { DiceReel } from './DiceReel'
+import { JudgmentBadge } from './JudgmentBadge'
 import { calcTotalAnimDuration, SPIN_DURATION, STOP_INTERVAL } from './diceAnimUtils'
 
 interface DiceResultCardProps {
@@ -19,6 +21,17 @@ export function DiceResultCard({ message, isNew }: DiceResultCardProps) {
     const timer = setTimeout(() => setTotalRevealed(true), duration)
     return () => clearTimeout(timer)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Build DieStyle lookup from message (if present)
+  const dieStyleMap = useMemo(() => {
+    const map = new Map<string, DieStyle>()
+    if (message.dieStyles) {
+      for (const ds of message.dieStyles) {
+        map.set(`${ds.termIndex}-${ds.dieIndex}`, ds)
+      }
+    }
+    return map
+  }, [message.dieStyles])
 
   // Count total dice and build shuffled stop order
   const totalDice = message.terms.reduce(
@@ -55,6 +68,7 @@ export function DiceResultCard({ message, isNew }: DiceResultCardProps) {
       const stopDelay = SPIN_DURATION + order * STOP_INTERVAL
       diceIndex++
       const isDropped = !tr.keptIndices.includes(ri)
+      const style = dieStyleMap.get(`${ti}-${ri}`)
       return (
         <DiceReel
           key={`${ti}-${ri}`}
@@ -63,6 +77,8 @@ export function DiceResultCard({ message, isNew }: DiceResultCardProps) {
           stopDelay={shouldAnimate.current ? stopDelay : 0}
           dropped={isDropped}
           dropRevealDelay={shouldAnimate.current ? allLandedTime : undefined}
+          color={style?.color}
+          label={style?.label}
         />
       )
     })
@@ -149,6 +165,11 @@ export function DiceResultCard({ message, isNew }: DiceResultCardProps) {
         >
           {totalRevealed ? message.total : '?'}
         </span>
+
+        {/* Judgment badge (appears after total reveal) */}
+        {totalRevealed && message.judgmentDisplay && (
+          <JudgmentBadge display={message.judgmentDisplay} animate={shouldAnimate.current} />
+        )}
       </div>
     </>
   )

--- a/src/chat/JudgmentBadge.tsx
+++ b/src/chat/JudgmentBadge.tsx
@@ -1,0 +1,55 @@
+import type { JudgmentDisplay } from '../rules/types'
+
+interface JudgmentBadgeProps {
+  display: JudgmentDisplay
+  animate?: boolean
+}
+
+const severityAnimations: Record<JudgmentDisplay['severity'], string> = {
+  critical: 'judgmentPulse 1.5s ease-in-out infinite',
+  success: 'judgmentPop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)',
+  partial: 'judgmentPop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)',
+  failure: 'judgmentShake 0.4s ease-in-out',
+  fumble: 'judgmentShake 0.5s ease-in-out',
+}
+
+export function JudgmentBadge({ display, animate = true }: JudgmentBadgeProps) {
+  return (
+    <>
+      <style>{`
+        @keyframes judgmentPulse {
+          0%, 100% { box-shadow: 0 0 8px ${display.color}66; }
+          50% { box-shadow: 0 0 20px ${display.color}CC; }
+        }
+        @keyframes judgmentPop {
+          0% { transform: scale(0.5); opacity: 0; }
+          60% { transform: scale(1.15); }
+          100% { transform: scale(1); opacity: 1; }
+        }
+        @keyframes judgmentShake {
+          0%, 100% { transform: translateX(0); }
+          20% { transform: translateX(-3px); }
+          40% { transform: translateX(3px); }
+          60% { transform: translateX(-2px); }
+          80% { transform: translateX(2px); }
+        }
+      `}</style>
+      <span
+        style={{
+          display: 'inline-block',
+          padding: '3px 10px',
+          borderRadius: 6,
+          fontSize: 12,
+          fontWeight: 700,
+          color: display.color,
+          background: `${display.color}1A`,
+          border: `1px solid ${display.color}33`,
+          animation: animate ? severityAnimations[display.severity] : 'none',
+          letterSpacing: 0.3,
+        }}
+      >
+        {display.text}
+      </span>
+    </>
+  )
+}

--- a/src/chat/MessageCard.tsx
+++ b/src/chat/MessageCard.tsx
@@ -147,6 +147,20 @@ export const MessageCard: React.FC<MessageCardProps> = ({
         <div style={{ ...headerStyle, flexWrap: 'wrap' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span style={nameStyle}>{message.senderName}</span>
+            {message.actionName && (
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: 'rgba(147,197,253,0.8)',
+                  background: 'rgba(59,130,246,0.15)',
+                  padding: '1px 7px',
+                  borderRadius: 4,
+                }}
+              >
+                {message.actionName}
+              </span>
+            )}
             <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)', fontFamily: 'monospace' }}>
               .r {message.expression}
               {message.resolvedExpression && (

--- a/src/chat/RollConfirmPanel.tsx
+++ b/src/chat/RollConfirmPanel.tsx
@@ -1,0 +1,236 @@
+import { useState, useRef, useEffect } from 'react'
+import type { RollAction, ModifierOption, RollContext } from '../rules/types'
+import { MiniHoldButton } from '../shared/ui/MiniHoldButton'
+
+interface RollConfirmPanelProps {
+  action: RollAction
+  resolvedFormula: string
+  modifierOptions: ModifierOption[]
+  onConfirm: (context: RollContext) => void
+  onCancel: () => void
+}
+
+export function RollConfirmPanel({
+  action,
+  resolvedFormula,
+  modifierOptions,
+  onConfirm,
+  onCancel,
+}: RollConfirmPanelProps) {
+  const [dc, setDc] = useState<string>('')
+  const [tempModifier, setTempModifier] = useState(0)
+  const [activeModifiers, setActiveModifiers] = useState<Set<string>>(new Set())
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Click outside to close
+  useEffect(() => {
+    const handler = (e: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onCancel()
+      }
+    }
+    document.addEventListener('pointerdown', handler)
+    return () => document.removeEventListener('pointerdown', handler)
+  }, [onCancel])
+
+  const handleConfirm = () => {
+    const dcNum = dc.trim() ? parseInt(dc) : undefined
+    onConfirm({
+      dc: dcNum && !isNaN(dcNum) ? dcNum : undefined,
+      activeModifierIds: [...activeModifiers],
+      tempModifier,
+    })
+  }
+
+  // Escape to close
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+      if (e.key === 'Enter') handleConfirm()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel, handleConfirm])
+
+  const toggleModifier = (id: string) => {
+    setActiveModifiers((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        // Handle mutual exclusivity
+        const opt = modifierOptions.find((o) => o.id === id)
+        if (opt?.mutuallyExclusiveWith) next.delete(opt.mutuallyExclusiveWith)
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    padding: '5px 8px',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 6,
+    fontSize: 13,
+    background: 'rgba(255,255,255,0.06)',
+    color: '#e4e4e7',
+    outline: 'none',
+    textAlign: 'center',
+    width: 50,
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 10002,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.4)',
+      }}
+    >
+      <div
+        ref={panelRef}
+        style={{
+          width: 320,
+          background: 'rgba(15, 15, 25, 0.92)',
+          backdropFilter: 'blur(16px)',
+          borderRadius: 14,
+          border: '1px solid rgba(255,255,255,0.1)',
+          boxShadow: '0 16px 48px rgba(0,0,0,0.5)',
+          padding: '20px 24px',
+          fontFamily: 'sans-serif',
+          color: '#e4e4e7',
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>{action.name}</div>
+        <div
+          style={{
+            fontSize: 13,
+            color: 'rgba(255,255,255,0.5)',
+            fontFamily: 'monospace',
+            marginBottom: 16,
+          }}
+        >
+          {resolvedFormula}
+          {tempModifier !== 0 && (
+            <span style={{ color: tempModifier > 0 ? '#22c55e' : '#ef4444' }}>
+              {tempModifier > 0 ? `+${tempModifier}` : tempModifier}
+            </span>
+          )}
+        </div>
+
+        {/* DC input */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 14,
+          }}
+        >
+          <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.5)', minWidth: 24 }}>DC</span>
+          <input
+            value={dc}
+            onChange={(e) => setDc(e.target.value.replace(/[^\d]/g, ''))}
+            placeholder="—"
+            style={inputStyle}
+          />
+        </div>
+
+        {/* Temp modifier */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 14,
+          }}
+        >
+          <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.5)', minWidth: 24 }}>Mod</span>
+          <MiniHoldButton label="−" onTick={() => setTempModifier((v) => v - 1)} color="#ef4444" />
+          <span
+            style={{
+              fontSize: 16,
+              fontWeight: 700,
+              fontFamily: 'monospace',
+              minWidth: 30,
+              textAlign: 'center',
+              color: tempModifier === 0 ? '#94a3b8' : tempModifier > 0 ? '#22c55e' : '#ef4444',
+            }}
+          >
+            {tempModifier >= 0 ? `+${tempModifier}` : tempModifier}
+          </span>
+          <MiniHoldButton label="+" onTick={() => setTempModifier((v) => v + 1)} color="#22c55e" />
+        </div>
+
+        {/* Modifier options */}
+        {modifierOptions.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 16 }}>
+            {modifierOptions.map((opt) => {
+              const active = activeModifiers.has(opt.id)
+              return (
+                <button
+                  key={opt.id}
+                  onClick={() => toggleModifier(opt.id)}
+                  style={{
+                    padding: '5px 12px',
+                    borderRadius: 8,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    border: active
+                      ? '1px solid rgba(59,130,246,0.5)'
+                      : '1px solid rgba(255,255,255,0.1)',
+                    background: active ? 'rgba(59,130,246,0.2)' : 'rgba(255,255,255,0.04)',
+                    color: active ? '#93c5fd' : 'rgba(255,255,255,0.5)',
+                    transition: 'all 0.15s',
+                  }}
+                >
+                  {opt.label}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            onClick={onCancel}
+            style={{
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: 'transparent',
+              color: 'rgba(255,255,255,0.5)',
+              fontSize: 13,
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            style={{
+              padding: '8px 20px',
+              borderRadius: 8,
+              border: 'none',
+              background: 'rgba(59,130,246,0.8)',
+              color: '#fff',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Roll
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/chat/chatTypes.ts
+++ b/src/chat/chatTypes.ts
@@ -1,5 +1,5 @@
 import type { DiceTermResult } from '../shared/diceUtils'
-import type { JudgmentResult } from '../rules/types'
+import type { JudgmentResult, DieStyle, JudgmentDisplay } from '../rules/types'
 
 export interface ChatTextMessage {
   type: 'text'
@@ -26,6 +26,8 @@ export interface ChatRollMessage {
   timestamp: number
   actionName?: string
   judgment?: JudgmentResult
+  dieStyles?: DieStyle[]
+  judgmentDisplay?: JudgmentDisplay
   modifiersApplied?: string[]
 }
 

--- a/src/entities/useEntities.ts
+++ b/src/entities/useEntities.ts
@@ -6,6 +6,106 @@ import type { WorldMaps } from '../yjs/useWorld'
 
 type EntityWithSource = Entity & { _source: 'party' | 'prepared' | string }
 
+/**
+ * Read ruleData from a nested Y.Map structure back into a plain object.
+ * Backward compat: if ruleData is a plain value (old data), returns it directly.
+ */
+function readRuleDataFromYMap(yMap: Y.Map<unknown>): unknown {
+  const ruleDataVal = yMap.get('ruleData')
+  if (!(ruleDataVal instanceof Y.Map)) return ruleDataVal ?? null
+
+  const rd: Record<string, unknown> = {}
+  ruleDataVal.forEach((val: unknown, key: string) => {
+    if (val instanceof Y.Map) {
+      const arr: unknown[] = []
+      ;(val as Y.Map<unknown>).forEach((v: unknown) => arr.push(v))
+      rd[key] = arr
+    } else if (val instanceof Y.Array) {
+      rd[key] = (val as Y.Array<unknown>).toArray()
+    } else {
+      rd[key] = val
+    }
+  })
+  return rd
+}
+
+/**
+ * Write ruleData as a multi-level nested Y structure for fine-grained CRDT merging.
+ * resources → Y.Map (keyed by resource name)
+ * attributes → Y.Map (keyed by attribute name)
+ * statuses → Y.Array
+ */
+function setRuleDataYMaps(parentYMap: Y.Map<unknown>, ruleData: unknown) {
+  const ruleDataMap = new Y.Map<unknown>()
+  if (ruleData && typeof ruleData === 'object') {
+    const rd = ruleData as Record<string, unknown>
+
+    if (rd.resources && typeof rd.resources === 'object') {
+      const resMap = new Y.Map<unknown>()
+      const entries: [string, unknown][] = Array.isArray(rd.resources)
+        ? (rd.resources as Array<{ key: string }>).map((r) => [r.key, r])
+        : Object.entries(rd.resources as Record<string, unknown>)
+      for (const [k, v] of entries) resMap.set(k, v)
+      ruleDataMap.set('resources', resMap)
+    }
+
+    if (rd.attributes && typeof rd.attributes === 'object') {
+      const attrMap = new Y.Map<unknown>()
+      const entries: [string, unknown][] = Array.isArray(rd.attributes)
+        ? (rd.attributes as Array<{ key: string }>).map((a) => [a.key, a])
+        : Object.entries(rd.attributes as Record<string, unknown>)
+      for (const [k, v] of entries) attrMap.set(k, v)
+      ruleDataMap.set('attributes', attrMap)
+    }
+
+    if (Array.isArray(rd.statuses)) {
+      const statusArr = new Y.Array<unknown>()
+      statusArr.push(rd.statuses)
+      ruleDataMap.set('statuses', statusArr)
+    }
+
+    for (const [k, v] of Object.entries(rd)) {
+      if (!['resources', 'attributes', 'statuses'].includes(k)) {
+        ruleDataMap.set(k, v)
+      }
+    }
+  }
+  parentYMap.set('ruleData', ruleDataMap)
+}
+
+/**
+ * Merge ruleData updates into existing nested Y.Map structure.
+ * Only touches the specific sub-keys provided (e.g. { resources: { HP: {...} } }).
+ */
+function mergeRuleDataUpdate(partyYMap: Y.Map<unknown>, ruleDataUpdates: Record<string, unknown>) {
+  const ruleDataMap = partyYMap.get('ruleData')
+  if (!(ruleDataMap instanceof Y.Map)) {
+    setRuleDataYMaps(partyYMap, ruleDataUpdates)
+    return
+  }
+
+  for (const [subKey, subVal] of Object.entries(ruleDataUpdates)) {
+    if (subKey === 'resources' || subKey === 'attributes') {
+      let subMap = (ruleDataMap as Y.Map<unknown>).get(subKey)
+      if (!(subMap instanceof Y.Map)) {
+        subMap = new Y.Map<unknown>()
+        ;(ruleDataMap as Y.Map<unknown>).set(subKey, subMap)
+      }
+      if (typeof subVal === 'object' && subVal !== null && !Array.isArray(subVal)) {
+        for (const [k, v] of Object.entries(subVal as Record<string, unknown>)) {
+          ;(subMap as Y.Map<unknown>).set(k, v)
+        }
+      }
+    } else if (subKey === 'statuses' && Array.isArray(subVal)) {
+      const arr = new Y.Array<unknown>()
+      arr.push(subVal)
+      ;(ruleDataMap as Y.Map<unknown>).set('statuses', arr)
+    } else {
+      ;(ruleDataMap as Y.Map<unknown>).set(subKey, subVal)
+    }
+  }
+}
+
 function readYMapEntity(yMap: Y.Map<unknown>): Entity {
   return {
     id: yMap.get('id') as string,
@@ -15,7 +115,7 @@ function readYMapEntity(yMap: Y.Map<unknown>): Entity {
     size: (yMap.get('size') as number) ?? 1,
     blueprintId: yMap.get('blueprintId') as string | undefined,
     notes: (yMap.get('notes') as string) ?? '',
-    ruleData: yMap.get('ruleData') ?? null,
+    ruleData: readRuleDataFromYMap(yMap),
     permissions: (yMap.get('permissions') as Entity['permissions']) ?? {
       default: 'observer',
       seats: {},
@@ -31,7 +131,7 @@ function setYMapFields(yMap: Y.Map<unknown>, entity: Entity) {
   yMap.set('size', entity.size)
   if (entity.blueprintId) yMap.set('blueprintId', entity.blueprintId)
   yMap.set('notes', entity.notes)
-  yMap.set('ruleData', entity.ruleData)
+  setRuleDataYMaps(yMap, entity.ruleData)
   yMap.set('permissions', entity.permissions)
 }
 
@@ -151,7 +251,11 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
       if (partyYMap instanceof Y.Map) {
         yDoc.transact(() => {
           for (const [key, value] of Object.entries(updates)) {
-            partyYMap.set(key, value)
+            if (key === 'ruleData' && value && typeof value === 'object') {
+              mergeRuleDataUpdate(partyYMap, value as Record<string, unknown>)
+            } else {
+              partyYMap.set(key, value)
+            }
           }
         })
         return

--- a/src/layout/MyCharacterCard.tsx
+++ b/src/layout/MyCharacterCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { Entity } from '../shared/entityTypes'
+import type { RuleSystem, RollAction } from '../rules/types'
 import {
   getEntityResources,
   getEntityAttributes,
@@ -15,6 +16,8 @@ import { MiniHoldButton } from '../shared/ui/MiniHoldButton'
 interface MyCharacterCardProps {
   entity: Entity
   onUpdateEntity: (id: string, updates: Partial<Entity>) => void
+  ruleSystem?: RuleSystem
+  onRollAction?: (action: RollAction) => void
 }
 
 type TabId = 'resources' | 'attributes' | 'statuses' | 'notes'
@@ -69,7 +72,12 @@ function updateRuleData(entity: Entity, key: string, value: unknown): Partial<En
   return { ruleData: { ...rd, [key]: value } }
 }
 
-export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps) {
+export function MyCharacterCard({
+  entity,
+  onUpdateEntity,
+  ruleSystem,
+  onRollAction,
+}: MyCharacterCardProps) {
   const [open, setOpen] = useState(false)
   const [activeTab, setActiveTab] = useState<TabId>('resources')
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -562,223 +570,241 @@ export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps
             color: '#e4e4e7',
           }}
         >
-          {/* ── Header (portrait + name) ── */}
-          <div style={{ padding: '20px 16px 0', flexShrink: 0 }}>
-            {/* Portrait */}
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                marginBottom: 12,
-              }}
-            >
-              <div
-                style={{ position: 'relative', cursor: 'pointer' }}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                {entity.imageUrl ? (
-                  <img
-                    src={entity.imageUrl}
-                    alt={entity.name}
-                    style={{
-                      width: 80,
-                      height: 80,
-                      borderRadius: '50%',
-                      objectFit: 'cover',
-                      border: `3px solid ${entity.color}`,
-                      boxShadow: `0 0 20px ${entity.color}33`,
-                      display: 'block',
-                    }}
-                  />
-                ) : (
-                  <div
-                    style={{
-                      width: 80,
-                      height: 80,
-                      borderRadius: '50%',
-                      background: `linear-gradient(135deg, ${entity.color}, ${entity.color}99)`,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      color: '#fff',
-                      fontSize: 32,
-                      fontWeight: 700,
-                      boxShadow: `0 0 20px ${entity.color}33`,
-                    }}
-                  >
-                    {entity.name.charAt(0).toUpperCase()}
-                  </div>
-                )}
-                {uploading && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      inset: 0,
-                      borderRadius: '50%',
-                      background: 'rgba(0,0,0,0.5)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      color: '#fff',
-                    }}
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      style={{ animation: 'spin 1s linear infinite' }}
-                    >
-                      <path d="M12 2a10 10 0 0 1 10 10" />
-                    </svg>
-                  </div>
-                )}
-                <div
-                  style={{
-                    position: 'absolute',
-                    inset: 0,
-                    borderRadius: '50%',
-                    background: 'rgba(0,0,0,0)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    transition: 'background 0.2s',
-                  }}
-                  onMouseEnter={(e) => {
-                    ;(e.currentTarget as HTMLElement).style.background = 'rgba(0,0,0,0.3)'
-                  }}
-                  onMouseLeave={(e) => {
-                    ;(e.currentTarget as HTMLElement).style.background = 'rgba(0,0,0,0)'
-                  }}
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="white"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    style={{ opacity: 0.7 }}
-                  >
-                    <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
-                    <circle cx="12" cy="13" r="4" />
-                  </svg>
-                </div>
-              </div>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handlePortraitUpload}
-                style={{ display: 'none' }}
+          {ruleSystem ? (
+            /* ── Rule-managed content (portrait, name, everything) ── */
+            <div style={{ overflowY: 'auto', height: 680 }}>
+              <ruleSystem.EntityCard
+                entity={entity}
+                onUpdateEntity={onUpdateEntity}
+                onRollAction={onRollAction ?? (() => {})}
               />
             </div>
-
-            {/* Name */}
-            <div style={{ textAlign: 'center', marginBottom: 14 }}>
-              {editingName ? (
-                <input
-                  autoFocus
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  onBlur={handleSaveName}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSaveName()
-                    if (e.key === 'Escape') {
-                      setEditingName(false)
-                      setEditName(entity.name)
-                    }
-                  }}
-                  style={{
-                    width: '80%',
-                    padding: '3px 8px',
-                    border: '1px solid rgba(255,255,255,0.2)',
-                    borderRadius: 6,
-                    fontSize: 16,
-                    fontWeight: 700,
-                    background: 'rgba(255,255,255,0.06)',
-                    color: '#fff',
-                    outline: 'none',
-                    textAlign: 'center',
-                    letterSpacing: 0.3,
-                    boxSizing: 'border-box',
-                    fontFamily: 'sans-serif',
-                  }}
-                />
-              ) : (
+          ) : (
+            /* ── Fallback: generic tabs (no rule system) ── */
+            <>
+              {/* ── Header (portrait + name) ── */}
+              <div style={{ padding: '20px 16px 0', flexShrink: 0 }}>
+                {/* Portrait */}
                 <div
-                  onClick={() => setEditingName(true)}
                   style={{
-                    fontWeight: 700,
-                    fontSize: 16,
-                    color: '#fff',
-                    letterSpacing: 0.3,
-                    cursor: 'text',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    marginBottom: 12,
                   }}
-                  title="Click to rename"
                 >
-                  {entity.name}
+                  <div
+                    style={{ position: 'relative', cursor: 'pointer' }}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    {entity.imageUrl ? (
+                      <img
+                        src={entity.imageUrl}
+                        alt={entity.name}
+                        style={{
+                          width: 80,
+                          height: 80,
+                          borderRadius: '50%',
+                          objectFit: 'cover',
+                          border: `3px solid ${entity.color}`,
+                          boxShadow: `0 0 20px ${entity.color}33`,
+                          display: 'block',
+                        }}
+                      />
+                    ) : (
+                      <div
+                        style={{
+                          width: 80,
+                          height: 80,
+                          borderRadius: '50%',
+                          background: `linear-gradient(135deg, ${entity.color}, ${entity.color}99)`,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          color: '#fff',
+                          fontSize: 32,
+                          fontWeight: 700,
+                          boxShadow: `0 0 20px ${entity.color}33`,
+                        }}
+                      >
+                        {entity.name.charAt(0).toUpperCase()}
+                      </div>
+                    )}
+                    {uploading && (
+                      <div
+                        style={{
+                          position: 'absolute',
+                          inset: 0,
+                          borderRadius: '50%',
+                          background: 'rgba(0,0,0,0.5)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          color: '#fff',
+                        }}
+                      >
+                        <svg
+                          width="20"
+                          height="20"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          style={{ animation: 'spin 1s linear infinite' }}
+                        >
+                          <path d="M12 2a10 10 0 0 1 10 10" />
+                        </svg>
+                      </div>
+                    )}
+                    <div
+                      style={{
+                        position: 'absolute',
+                        inset: 0,
+                        borderRadius: '50%',
+                        background: 'rgba(0,0,0,0)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        transition: 'background 0.2s',
+                      }}
+                      onMouseEnter={(e) => {
+                        ;(e.currentTarget as HTMLElement).style.background = 'rgba(0,0,0,0.3)'
+                      }}
+                      onMouseLeave={(e) => {
+                        ;(e.currentTarget as HTMLElement).style.background = 'rgba(0,0,0,0)'
+                      }}
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        style={{ opacity: 0.7 }}
+                      >
+                        <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                        <circle cx="12" cy="13" r="4" />
+                      </svg>
+                    </div>
+                  </div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handlePortraitUpload}
+                    style={{ display: 'none' }}
+                  />
                 </div>
-              )}
-            </div>
-          </div>
 
-          {/* ── Tab bar ── */}
-          <div
-            style={{
-              display: 'flex',
-              borderTop: '1px solid rgba(255,255,255,0.06)',
-              borderBottom: '1px solid rgba(255,255,255,0.06)',
-              flexShrink: 0,
-            }}
-          >
-            {TABS.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                {/* Name */}
+                <div style={{ textAlign: 'center', marginBottom: 14 }}>
+                  {editingName ? (
+                    <input
+                      autoFocus
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      onBlur={handleSaveName}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleSaveName()
+                        if (e.key === 'Escape') {
+                          setEditingName(false)
+                          setEditName(entity.name)
+                        }
+                      }}
+                      style={{
+                        width: '80%',
+                        padding: '3px 8px',
+                        border: '1px solid rgba(255,255,255,0.2)',
+                        borderRadius: 6,
+                        fontSize: 16,
+                        fontWeight: 700,
+                        background: 'rgba(255,255,255,0.06)',
+                        color: '#fff',
+                        outline: 'none',
+                        textAlign: 'center',
+                        letterSpacing: 0.3,
+                        boxSizing: 'border-box',
+                        fontFamily: 'sans-serif',
+                      }}
+                    />
+                  ) : (
+                    <div
+                      onClick={() => setEditingName(true)}
+                      style={{
+                        fontWeight: 700,
+                        fontSize: 16,
+                        color: '#fff',
+                        letterSpacing: 0.3,
+                        cursor: 'text',
+                      }}
+                      title="Click to rename"
+                    >
+                      {entity.name}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* ── Tab bar ── */}
+              <div
                 style={{
-                  flex: 1,
-                  padding: '8px 0',
-                  background: activeTab === tab.id ? 'rgba(255,255,255,0.06)' : 'transparent',
-                  border: 'none',
-                  borderBottom:
-                    activeTab === tab.id ? `2px solid ${entity.color}` : '2px solid transparent',
-                  cursor: 'pointer',
-                  color: activeTab === tab.id ? '#fff' : 'rgba(255,255,255,0.35)',
-                  fontSize: 9,
-                  fontWeight: 700,
-                  letterSpacing: 0.8,
-                  textTransform: 'uppercase',
-                  transition: 'color 0.15s, background 0.15s, border-color 0.15s',
-                  fontFamily: 'sans-serif',
-                }}
-                onMouseEnter={(e) => {
-                  if (activeTab !== tab.id) e.currentTarget.style.color = 'rgba(255,255,255,0.6)'
-                }}
-                onMouseLeave={(e) => {
-                  if (activeTab !== tab.id) e.currentTarget.style.color = 'rgba(255,255,255,0.35)'
+                  display: 'flex',
+                  borderTop: '1px solid rgba(255,255,255,0.06)',
+                  borderBottom: '1px solid rgba(255,255,255,0.06)',
+                  flexShrink: 0,
                 }}
               >
-                {tab.label}
-              </button>
-            ))}
-          </div>
+                {TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    style={{
+                      flex: 1,
+                      padding: '8px 0',
+                      background: activeTab === tab.id ? 'rgba(255,255,255,0.06)' : 'transparent',
+                      border: 'none',
+                      borderBottom:
+                        activeTab === tab.id
+                          ? `2px solid ${entity.color}`
+                          : '2px solid transparent',
+                      cursor: 'pointer',
+                      color: activeTab === tab.id ? '#fff' : 'rgba(255,255,255,0.35)',
+                      fontSize: 9,
+                      fontWeight: 700,
+                      letterSpacing: 0.8,
+                      textTransform: 'uppercase',
+                      transition: 'color 0.15s, background 0.15s, border-color 0.15s',
+                      fontFamily: 'sans-serif',
+                    }}
+                    onMouseEnter={(e) => {
+                      if (activeTab !== tab.id)
+                        e.currentTarget.style.color = 'rgba(255,255,255,0.6)'
+                    }}
+                    onMouseLeave={(e) => {
+                      if (activeTab !== tab.id)
+                        e.currentTarget.style.color = 'rgba(255,255,255,0.35)'
+                    }}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
 
-          {/* ── Tab content (fixed height, scroll if needed) ── */}
-          <div
-            style={{
-              padding: '14px 16px 16px',
-              overflowY: 'auto',
-              height: 500,
-            }}
-          >
-            {tabContent[activeTab]()}
-          </div>
+              {/* ── Tab content (fixed height, scroll if needed) ── */}
+              <div
+                style={{
+                  padding: '14px 16px 16px',
+                  overflowY: 'auto',
+                  height: 500,
+                }}
+              >
+                {tabContent[activeTab]()}
+              </div>
+            </>
+          )}
         </div>
 
         {/* Tab handle — always visible */}

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -23,6 +23,7 @@ interface PortraitBarProps {
   onSetActiveCharacter: (charId: string) => void
   onDeleteEntity: (entityId: string) => void
   onUpdateEntity: (id: string, updates: Partial<Entity>) => void
+  onAddPC?: () => void
 }
 
 const PORTRAIT_SIZE = 52
@@ -88,6 +89,7 @@ export function PortraitBar({
   onSetActiveCharacter,
   onDeleteEntity,
   onUpdateEntity,
+  onAddPC,
 }: PortraitBarProps) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; entityId: string } | null>(
     null,
@@ -166,7 +168,7 @@ export function PortraitBar({
   // Filter to entities visible to this seat
   const visibleEntities = entities.filter((e) => (mySeatId ? canSee(e, mySeatId, role) : isGM))
 
-  if (visibleEntities.length === 0) return null
+  if (visibleEntities.length === 0 && !onAddPC) return null
 
   // Split by ownership: "party" entities (owner exists) vs scene entities (no owners)
   const partyEntities = visibleEntities.filter((e) =>
@@ -520,6 +522,38 @@ export function PortraitBar({
           )}
 
           {sceneEntities.map(renderPortrait)}
+
+          {/* Add PC button */}
+          {onAddPC && (
+            <div
+              onClick={onAddPC}
+              style={{
+                width: PORTRAIT_SIZE,
+                height: PORTRAIT_SIZE,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                borderRadius: '50%',
+                border: '2px dashed rgba(255,255,255,0.2)',
+                color: 'rgba(255,255,255,0.35)',
+                fontSize: 20,
+                fontWeight: 300,
+                transition: 'border-color 0.15s, color 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                ;(e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,0.4)'
+                ;(e.currentTarget as HTMLElement).style.color = 'rgba(255,255,255,0.6)'
+              }}
+              onMouseLeave={(e) => {
+                ;(e.currentTarget as HTMLElement).style.borderColor = 'rgba(255,255,255,0.2)'
+                ;(e.currentTarget as HTMLElement).style.color = 'rgba(255,255,255,0.35)'
+              }}
+              title="Create new character"
+            >
+              +
+            </div>
+          )}
         </div>
       )}
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -63,6 +63,13 @@ export interface EntityCardProps {
   onRollAction: (action: RollAction) => void
 }
 
+/** A custom chat command registered by a rule system (e.g. ".dd" for Daggerheart duality dice) */
+export interface ChatCommand {
+  prefix: string // ".dd" — the dot-command trigger
+  name: string // "Duality Roll" — used as actionName on the roll message
+  buildFormula: (args: string) => string // ".dd +2" → "2d12+2"
+}
+
 /** The main interface rules implement */
 export interface RuleSystem {
   id: string
@@ -86,4 +93,8 @@ export interface RuleSystem {
   getDieStyles(termResults: DiceTermResult[]): DieStyle[]
   getJudgmentDisplay(result: JudgmentResult): JudgmentDisplay
   getModifierOptions(): ModifierOption[]
+  // Chat commands
+  getChatCommands(): ChatCommand[]
+  // Defaults
+  getDefaultRuleData(): unknown
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

- 为基座组件添加规则系统扩展点，允许规则模块（如 Daggerheart）在不修改基座代码的情况下定制 VTT 行为
- `RuleSystem` 接口扩展：`ChatCommand` 注册、`EntityCard` 委托、掷骰评估/enrichment、骰子样式、判定显示
- `ChatInput`：`customCommands` prop 支持规则注册的 dot-command（如 `.dd`）
- `ChatPanel`：`ruleSystem` prop + 自动掷骰 enrichment（judgment/dieStyles/judgmentDisplay）
- `MyCharacterCard`：有 RuleSystem 时委托给 `ruleSystem.EntityCard`，无则保留通用 tabs
- `PortraitBar`：`onAddPC` prop + "+" 按钮用于角色创建
- `DiceReel`：`color`/`label` props 支持规则自定义骰子样式
- `DiceResultCard`：DieStyle lookup + JudgmentBadge 渲染
- `MessageCard`：命名掷骰的 `actionName` 标签
- `useEntities`：嵌套 Y.Map ruleData 支持细粒度 CRDT 合并（resources/attributes 独立 key）
- `JudgmentBadge` + `RollConfirmPanel`：新增共享 UI 组件

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] 无 RuleSystem 时所有现有功能不变（ChatInput、MyCharacterCard tabs、PortraitBar）
- [ ] `customCommands` prop 正确传递并触发自定义命令
- [ ] `actionName` 在 MessageCard 中正确显示
- [ ] DiceReel 的 `color`/`label` props 正确渲染
- [ ] 嵌套 Y.Map ruleData 的读写和向后兼容性

🤖 Generated with [Claude Code](https://claude.com/claude-code)