### PR TITLE
refactor: clean up Yjs data structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,20 +38,25 @@ myVTT is a lightweight Virtual Tabletop built with React + Yjs + y-websocket for
 
 - `yDoc` created in `useState` (not useEffect) for component sharing
 - Do NOT call `yDoc.destroy()` in cleanup - lifecycle managed by useState
-- Global containers use top-level shared types: `yDoc.getMap('world:seats')`, `yDoc.getMap('world:room')`, `yDoc.getArray('world:chat')`, etc. — managed via `createWorldMaps()` in `src/yjs/useWorld.ts`
-- Scene data uses nested Y.Maps: `world:scenes` → `sceneId` → `entities`/`tokens` (created by user action, not auto-init)
+- All containers use top-level shared types: `yDoc.getMap('scenes')`, `yDoc.getMap('room')`, etc. — managed via `createWorldMaps()` in `src/yjs/useWorld.ts`
+- Top-level keys: `scenes`, `roster`, `blueprints`, `seats`, `room`, `chat_log`, `team_metrics`, `showcase_items`, `handout_assets`
+- Scene data uses nested Y.Maps: `scenes` → `sceneId` → `entities`/`tokens` (created by user action, not auto-init)
+- Roster entities use nested Y.Maps with `permissions` and `ruleData` as nested Y.Map structures for field-level CRDT
 
 **Yjs Nesting Rules (IMPORTANT):**
 
-- Global containers (seats, room, scenes, party, etc.) MUST use top-level shared types: `yDoc.getMap('world:xxx')` / `yDoc.getArray('world:xxx')`
+- Global containers (seats, room, scenes, roster, etc.) MUST use top-level shared types: `yDoc.getMap('xxx')`
 - NEVER use `ensureSubMap` or check-then-create patterns (`if (!exists) parent.set(key, new Y.Map())`) during initialization — this causes race conditions when multiple clients connect before sync completes
 - Nested Y.Map creation (`parent.set(key, new Y.Map())`) is ONLY allowed inside explicit user actions (e.g., addScene), where: (1) the operation happens after WebSocket sync is complete, (2) the key is a unique ID (UUID), not a fixed string, (3) only one client triggers the creation
+- Plain objects stored as Y.Map values have NO field-level CRDT — use nested Y.Map for fields that need concurrent editing
 
 **Entity System:**
 
-- Core type: `Entity` (id, name, avatar, permissions, resources, attributes, statuses, notes)
-- Combat tokens: `MapToken` extends Entity with map coordinates (x, y, size)
-- Blueprints: reusable token templates stored in `token_blueprints` map
+- Core type: `Entity` (id, name, imageUrl, color, size, notes, ruleData, permissions)
+- `roster` = cross-scene persistent characters (PC + NPC), nested Y.Map with field-level CRDT
+- `scene.entities` = scene-specific entities, plain objects
+- Combat tokens: `MapToken` with optional entityId for linking to entities
+- Blueprints: reusable token templates stored in `blueprints` map
 - Adapters: `entityAdapters.ts` provides read-only getters (getEntityResources, getEntityAttributes, etc.)
 
 ### react-zoom-pan-pinch

--- a/docs/architecture/yjs-data-structure.md
+++ b/docs/architecture/yjs-data-structure.md
@@ -1,0 +1,118 @@
+# Yjs 数据结构
+
+> 本文档描述 Y.Doc 的完整数据结构、存储模式和数据流。
+
+---
+
+## 一、Y.Doc 完整结构
+
+所有容器使用 `yDoc.getMap('xxx')` 顶层共享类型，保证多客户端实例唯一，无竞态条件。
+
+```
+Y.Doc（顶层共享类型）
+│
+│   ── WorldMaps（通过 createWorldMaps 统一管理）──
+│
+├── 'room'             (Y.Map)                    ← 房间状态
+│   ├── mode: 'scene' | 'combat'
+│   ├── activeSceneId: string | null
+│   ├── combatSceneId: string | null
+│   └── pinnedShowcaseId?: string
+│
+├── 'scenes'           (Y.Map<Y.Map>)             ← 场景定义
+│   └── [sceneId]      (Y.Map)
+│       ├── name, imageUrl, width, height: string/number
+│       ├── gridSize, gridVisible, gridColor: number/boolean/string
+│       ├── gridOffsetX, gridOffsetY: number
+│       ├── sortOrder: number
+│       ├── 'entities'  (Y.Map<Entity>)            ← 场景实体（plain object）
+│       └── 'tokens'    (Y.Map<MapToken>)           ← 战斗 token（plain object）
+│
+├── 'roster'           (Y.Map<Y.Map>)              ← 跨场景持久角色名册
+│   └── [entityId]     (Y.Map)
+│       ├── id, name, imageUrl, color, size, notes  ← 基础字段（字段级 CRDT）
+│       ├── blueprintId?: string
+│       ├── 'ruleData'      (Y.Map)                 ← 规则数据（顶层 key 级 CRDT）
+│       │   ├── kind: string
+│       │   ├── level: number
+│       │   ├── resources: { ... }                   ← 各 key 内部仍是 plain object
+│       │   └── attributes: { ... }
+│       └── 'permissions'   (Y.Map)                  ← 权限（字段级 CRDT）
+│           ├── default: 'none' | 'observer' | 'owner'
+│           └── 'seats'     (Y.Map)                   ← 每个座位独立 CRDT
+│               ├── [seatId]: 'none' | 'observer' | 'owner'
+│               └── ...
+│
+├── 'blueprints'       (Y.Map)                     ← Token 模板（plain object）
+│   └── [blueprintId] → Blueprint
+│
+├── 'seats'            (Y.Map)                     ← 玩家座位（plain object）
+│   └── [seatId] → Seat { id, name, color, role, portraitUrl?, activeCharacterId? }
+│
+│   ── 独立于 WorldMaps 的根级别数据 ──
+│
+├── 'chat_log'         (Y.Array<ChatMessage>)      ← 聊天消息
+│
+├── 'team_metrics'     (Y.Map<TeamTracker>)        ← 团队追踪器
+│
+├── 'showcase_items'   (Y.Map<ShowcaseItem>)       ← 展示卡片
+│
+└── 'handout_assets'   (Y.Map<HandoutAsset>)       ← 讲义素材库
+```
+
+## 二、存储模式对照
+
+| 容器               | Y.Doc key         | 存储方式                         | Observer             | 并发安全        |
+| ------------------ | ----------------- | -------------------------------- | -------------------- | --------------- |
+| roster             | `roster`          | 嵌套 Y.Map（字段级 CRDT）        | `.observeDeep()`     | 字段级合并      |
+| roster.permissions | 嵌套于 entity Map | 嵌套 Y.Map（seats 为独立 Y.Map） | via `.observeDeep()` | 字段级合并      |
+| roster.ruleData    | 嵌套于 entity Map | 嵌套 Y.Map（顶层 key 级）        | via `.observeDeep()` | 顶层 key 级合并 |
+| scenes             | `scenes`          | 嵌套 Y.Map（配置 + 子容器）      | `.observeDeep()`     | 字段级合并      |
+| scene.entities     | 嵌套于 scene Map  | plain object 整体替换            | `.observe()`         | 后写入胜        |
+| scene.tokens       | 嵌套于 scene Map  | plain object 整体替换            | `.observe()`         | 后写入胜        |
+| blueprints         | `blueprints`      | plain object 整体替换            | `.observe()`         | 后写入胜        |
+| seats              | `seats`           | plain object 整体替换            | `.observe()`         | 后写入胜        |
+| chat_log           | `chat_log`        | plain object 追加                | `.observe(event)`    | 追加安全        |
+| team_metrics       | `team_metrics`    | plain object 整体替换            | `.observe()`         | 后写入胜        |
+| showcase_items     | `showcase_items`  | plain object 整体替换            | `.observe()`         | 后写入胜        |
+| handout_assets     | `handout_assets`  | plain object 整体替换            | `.observe()`         | 后写入胜        |
+
+## 三、数据流概览
+
+```
+useYjsConnection(roomId)             → Y.Doc + WebsocketProvider + Awareness
+  └→ useWorld(yDoc)                  → WorldMaps（createWorldMaps 统一创建）
+      ├→ useRoom(world.room)         → 'room' map
+      ├→ useScenes(world.scenes)     → 'scenes' map
+      ├→ useEntities(world, ...)     → 聚合 roster + scene.entities
+      ├→ useSceneTokens(world)       → scene 内嵌套的 tokens map
+      └→ useIdentity(world.seats)    → 'seats' map
+  └→ ChatPanel(yDoc)                 → yDoc.getArray('chat_log')
+  └→ useShowcase(yDoc)               → yDoc.getMap('showcase_items') + yDoc.getMap('room')
+  └→ useTeamMetrics(yDoc)            → yDoc.getMap('team_metrics')
+  └→ useHandoutAssets(yDoc)          → yDoc.getMap('handout_assets')
+```
+
+## 四、Yjs 安全规则
+
+### 顶层共享类型 vs 嵌套 Y.Map
+
+`yDoc.getMap('xxx')` 是 Yjs **顶层共享类型**——无论多少客户端调用，返回的永远是同一个实例，不存在竞态问题。
+
+嵌套 Y.Map（`parent.set(key, new Y.Map())`）只在以下条件下安全：
+
+1. key 是 UUID（非固定字符串）
+2. 只有一个客户端触发创建
+3. WebSocket 同步已完成
+
+### 并发安全的权限/规则数据
+
+Roster 中的 `permissions` 和 `ruleData` 使用嵌套 Y.Map 结构：
+
+- `permissions.seats` 是独立 Y.Map，不同客户端可并发修改不同座位的权限
+- `ruleData` 顶层 key 是独立条目，不同客户端可并发修改 `resources` 和 `attributes` 而不冲突
+- 场景实体（`scene.entities`）使用 plain object 整体替换，因为只有 GM 操作
+
+### 回归测试
+
+`src/yjs/__tests__/useWorld.test.ts` 包含孤儿引用竞态条件的回归测试，验证了旧 `ensureSubMap` 模式的破坏性行为。

--- a/src/entities/__tests__/useEntities.test.ts
+++ b/src/entities/__tests__/useEntities.test.ts
@@ -32,33 +32,20 @@ describe('useEntities', () => {
     expect(hook.result.current.entities).toEqual([])
   })
 
-  // ── addPartyEntity ──────────────────────────────────────────
+  // ── addRosterEntity ───────────────────────────────────────
 
-  it('adds a party entity', () => {
+  it('adds a roster entity', () => {
     const { hook } = setup()
     const entity = makeEntity({ id: 'pc-1', name: 'Fighter' })
 
-    act(() => hook.result.current.addPartyEntity(entity))
+    act(() => hook.result.current.addRosterEntity(entity))
 
     const found = hook.result.current.entities.find((e) => e.id === 'pc-1')
     expect(found).toBeDefined()
     expect(found?.name).toBe('Fighter')
   })
 
-  // ── addPreparedEntity ───────────────────────────────────────
-
-  it('adds a prepared entity', () => {
-    const { hook } = setup()
-    const entity = makeEntity({ id: 'npc-1', name: 'Goblin' })
-
-    act(() => hook.result.current.addPreparedEntity(entity))
-
-    const found = hook.result.current.entities.find((e) => e.id === 'npc-1')
-    expect(found).toBeDefined()
-    expect(found?.name).toBe('Goblin')
-  })
-
-  // ── addSceneEntity ──────────────────────────────────────────
+  // ── addSceneEntity ────────────────────────────────────────
 
   it('adds a scene entity', () => {
     const { hook } = setup()
@@ -73,22 +60,13 @@ describe('useEntities', () => {
 
   // ── updateEntity (auto-detect source) ───────────────────────
 
-  it('updates a party entity', () => {
+  it('updates a roster entity', () => {
     const { hook } = setup()
-    act(() => hook.result.current.addPartyEntity(makeEntity({ id: 'pc-1', name: 'Fighter' })))
+    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1', name: 'Fighter' })))
 
     act(() => hook.result.current.updateEntity('pc-1', { name: 'Paladin' }))
 
     expect(hook.result.current.entities.find((e) => e.id === 'pc-1')?.name).toBe('Paladin')
-  })
-
-  it('updates a prepared entity', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.addPreparedEntity(makeEntity({ id: 'npc-1', name: 'Goblin' })))
-
-    act(() => hook.result.current.updateEntity('npc-1', { name: 'Hobgoblin' }))
-
-    expect(hook.result.current.entities.find((e) => e.id === 'npc-1')?.name).toBe('Hobgoblin')
   })
 
   it('updates a scene entity', () => {
@@ -102,21 +80,12 @@ describe('useEntities', () => {
 
   // ── deleteEntity (auto-detect source) ───────────────────────
 
-  it('deletes a party entity', () => {
+  it('deletes a roster entity', () => {
     const { hook } = setup()
-    act(() => hook.result.current.addPartyEntity(makeEntity({ id: 'pc-1' })))
+    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1' })))
     expect(hook.result.current.entities).toHaveLength(1)
 
     act(() => hook.result.current.deleteEntity('pc-1'))
-
-    expect(hook.result.current.entities).toHaveLength(0)
-  })
-
-  it('deletes a prepared entity', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.addPreparedEntity(makeEntity({ id: 'npc-1' })))
-
-    act(() => hook.result.current.deleteEntity('npc-1'))
 
     expect(hook.result.current.entities).toHaveLength(0)
   })
@@ -130,16 +99,19 @@ describe('useEntities', () => {
     expect(hook.result.current.entities).toHaveLength(0)
   })
 
-  // ── promoteToGM ─────────────────────────────────────────────
+  // ── promoteToRoster ────────────────────────────────────────
 
-  it('promotes scene entity to prepared', () => {
+  it('promotes scene entity to roster', () => {
     const { hook, world } = setup()
     act(() => hook.result.current.addSceneEntity(makeEntity({ id: 'se-1', name: 'Trap' })))
 
-    act(() => hook.result.current.promoteToGM('se-1'))
+    act(() => hook.result.current.promoteToRoster('se-1'))
 
-    // Should now be in prepared, not in scene entities
-    expect(world.prepared.has('se-1')).toBe(true)
+    // Should now be in roster, not in scene entities
+    expect(world.roster.has('se-1')).toBe(true)
+    const rosterYMap = world.roster.get('se-1')
+    expect(rosterYMap).toBeInstanceOf(Y.Map)
+    expect((rosterYMap as Y.Map<unknown>).get('name')).toBe('Trap')
     const sceneMap = world.scenes.get(sceneId)
     const sceneEntities = (sceneMap as Y.Map<unknown>).get('entities') as Y.Map<unknown>
     expect(sceneEntities.has('se-1')).toBe(false)
@@ -149,7 +121,7 @@ describe('useEntities', () => {
 
   it('returns entity by id', () => {
     const { hook } = setup()
-    act(() => hook.result.current.addPartyEntity(makeEntity({ id: 'pc-1', name: 'Rogue' })))
+    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1', name: 'Rogue' })))
 
     expect(hook.result.current.getEntity('pc-1')?.name).toBe('Rogue')
   })
@@ -162,5 +134,170 @@ describe('useEntities', () => {
   it('returns null for null id', () => {
     const { hook } = setup()
     expect(hook.result.current.getEntity(null)).toBeNull()
+  })
+
+  // ── nested Y.Map: permissions & ruleData ───────────────────
+
+  it('stores permissions as nested Y.Map', () => {
+    const { hook, world } = setup()
+    const entity = makeEntity({
+      id: 'pc-1',
+      permissions: { default: 'observer', seats: { 'seat-1': 'owner' } },
+    })
+
+    act(() => hook.result.current.addRosterEntity(entity))
+
+    const yMap = world.roster.get('pc-1') as Y.Map<unknown>
+    const permYMap = yMap.get('permissions')
+    expect(permYMap).toBeInstanceOf(Y.Map)
+    expect((permYMap as Y.Map<unknown>).get('default')).toBe('observer')
+    const seatsYMap = (permYMap as Y.Map<unknown>).get('seats')
+    expect(seatsYMap).toBeInstanceOf(Y.Map)
+    expect((seatsYMap as Y.Map<unknown>).get('seat-1')).toBe('owner')
+  })
+
+  it('stores ruleData as nested Y.Map', () => {
+    const { hook, world } = setup()
+    const entity = makeEntity({
+      id: 'pc-1',
+      ruleData: { kind: 'pc', level: 3, resources: { hp: { cur: 10, max: 10 } } },
+    })
+
+    act(() => hook.result.current.addRosterEntity(entity))
+
+    const yMap = world.roster.get('pc-1') as Y.Map<unknown>
+    const ruleYMap = yMap.get('ruleData')
+    expect(ruleYMap).toBeInstanceOf(Y.Map)
+    expect((ruleYMap as Y.Map<unknown>).get('kind')).toBe('pc')
+    expect((ruleYMap as Y.Map<unknown>).get('level')).toBe(3)
+    expect((ruleYMap as Y.Map<unknown>).get('resources')).toEqual({ hp: { cur: 10, max: 10 } })
+  })
+
+  it('reads back permissions correctly from nested Y.Map', () => {
+    const { hook } = setup()
+    const entity = makeEntity({
+      id: 'pc-1',
+      permissions: { default: 'none', seats: { 'seat-1': 'owner', 'seat-2': 'observer' } },
+    })
+
+    act(() => hook.result.current.addRosterEntity(entity))
+
+    const found = hook.result.current.getEntity('pc-1')
+    expect(found?.permissions).toEqual({
+      default: 'none',
+      seats: { 'seat-1': 'owner', 'seat-2': 'observer' },
+    })
+  })
+
+  it('reads back ruleData correctly from nested Y.Map', () => {
+    const { hook } = setup()
+    const entity = makeEntity({
+      id: 'pc-1',
+      ruleData: { kind: 'pc', level: 3 },
+    })
+
+    act(() => hook.result.current.addRosterEntity(entity))
+
+    const found = hook.result.current.getEntity('pc-1')
+    expect(found?.ruleData).toEqual({ kind: 'pc', level: 3 })
+  })
+
+  it('null ruleData reads back as null', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1', ruleData: null })))
+
+    expect(hook.result.current.getEntity('pc-1')?.ruleData).toBeNull()
+  })
+
+  it('updates permissions via updateEntity', () => {
+    const { hook } = setup()
+    act(() =>
+      hook.result.current.addRosterEntity(
+        makeEntity({
+          id: 'pc-1',
+          permissions: { default: 'observer', seats: { 'seat-1': 'owner' } },
+        }),
+      ),
+    )
+
+    act(() =>
+      hook.result.current.updateEntity('pc-1', {
+        permissions: { default: 'none', seats: { 'seat-2': 'owner' } },
+      }),
+    )
+
+    const found = hook.result.current.getEntity('pc-1')
+    expect(found?.permissions).toEqual({
+      default: 'none',
+      seats: { 'seat-2': 'owner' },
+    })
+  })
+
+  it('updates ruleData via updateEntity (merges top-level keys)', () => {
+    const { hook } = setup()
+    act(() =>
+      hook.result.current.addRosterEntity(
+        makeEntity({
+          id: 'pc-1',
+          ruleData: { kind: 'pc', level: 3, resources: { hp: { cur: 10, max: 10 } } },
+        }),
+      ),
+    )
+
+    // Update only resources, kind and level should be preserved
+    act(() =>
+      hook.result.current.updateEntity('pc-1', {
+        ruleData: { resources: { hp: { cur: 5, max: 10 } } },
+      }),
+    )
+
+    const found = hook.result.current.getEntity('pc-1')
+    const ruleData = found?.ruleData as Record<string, unknown>
+    expect(ruleData.kind).toBe('pc')
+    expect(ruleData.level).toBe(3)
+    expect(ruleData.resources).toEqual({ hp: { cur: 5, max: 10 } })
+  })
+
+  it('concurrent permissions updates on different seats merge correctly', () => {
+    const doc1 = new Y.Doc()
+    const doc2 = new Y.Doc()
+
+    // Bidirectional sync
+    doc1.on('update', (update: Uint8Array) => Y.applyUpdate(doc2, update))
+    doc2.on('update', (update: Uint8Array) => Y.applyUpdate(doc1, update))
+
+    const rosterMap1 = doc1.getMap('roster') as Y.Map<Y.Map<unknown>>
+    const rosterMap2 = doc2.getMap('roster') as Y.Map<Y.Map<unknown>>
+
+    // Client 1 creates entity
+    doc1.transact(() => {
+      const yMap = new Y.Map<unknown>()
+      rosterMap1.set('pc-1', yMap)
+      yMap.set('id', 'pc-1')
+      yMap.set('name', 'Fighter')
+      const permYMap = new Y.Map<unknown>()
+      yMap.set('permissions', permYMap)
+      permYMap.set('default', 'observer')
+      const seatsYMap = new Y.Map<unknown>()
+      permYMap.set('seats', seatsYMap)
+    })
+
+    // Client 1 adds seat-1 permission
+    const entity1 = rosterMap1.get('pc-1') as Y.Map<unknown>
+    const perm1 = entity1.get('permissions') as Y.Map<unknown>
+    const seats1 = perm1.get('seats') as Y.Map<unknown>
+    seats1.set('seat-1', 'owner')
+
+    // Client 2 adds seat-2 permission (concurrently)
+    const entity2 = rosterMap2.get('pc-1') as Y.Map<unknown>
+    const perm2 = entity2.get('permissions') as Y.Map<unknown>
+    const seats2 = perm2.get('seats') as Y.Map<unknown>
+    seats2.set('seat-2', 'owner')
+
+    // Both should see both seats
+    expect(seats1.get('seat-1')).toBe('owner')
+    expect(seats1.get('seat-2')).toBe('owner')
+    expect(seats2.get('seat-1')).toBe('owner')
+    expect(seats2.get('seat-2')).toBe('owner')
   })
 })

--- a/src/entities/useEntities.ts
+++ b/src/entities/useEntities.ts
@@ -1,10 +1,43 @@
 // src/entities/useEntities.ts
 import { useEffect, useState, useCallback } from 'react'
 import * as Y from 'yjs'
-import type { Entity } from '../shared/entityTypes'
+import type { Entity, EntityPermissions, PermissionLevel } from '../shared/entityTypes'
 import type { WorldMaps } from '../yjs/useWorld'
 
-type EntityWithSource = Entity & { _source: 'party' | 'prepared' | string }
+type EntityWithSource = Entity & { _source: 'roster' | string }
+
+/** Read permissions from a nested Y.Map back to a plain EntityPermissions object */
+function readPermissions(yMap: Y.Map<unknown>): EntityPermissions {
+  const permYMap = yMap.get('permissions')
+  if (permYMap instanceof Y.Map) {
+    const seatsYMap = permYMap.get('seats')
+    const seats: Record<string, PermissionLevel> = {}
+    if (seatsYMap instanceof Y.Map) {
+      seatsYMap.forEach((val, key) => {
+        seats[key] = val as PermissionLevel
+      })
+    }
+    return {
+      default: (permYMap.get('default') as PermissionLevel) ?? 'observer',
+      seats,
+    }
+  }
+  return { default: 'observer', seats: {} }
+}
+
+/** Read ruleData from a nested Y.Map back to a plain object (or null) */
+function readRuleData(yMap: Y.Map<unknown>): unknown {
+  const ruleYMap = yMap.get('ruleData')
+  if (ruleYMap instanceof Y.Map) {
+    if (ruleYMap.size === 0) return null
+    const obj: Record<string, unknown> = {}
+    ruleYMap.forEach((val, key) => {
+      obj[key] = val
+    })
+    return obj
+  }
+  return null
+}
 
 function readYMapEntity(yMap: Y.Map<unknown>): Entity {
   return {
@@ -15,11 +48,31 @@ function readYMapEntity(yMap: Y.Map<unknown>): Entity {
     size: (yMap.get('size') as number) ?? 1,
     blueprintId: yMap.get('blueprintId') as string | undefined,
     notes: (yMap.get('notes') as string) ?? '',
-    ruleData: yMap.get('ruleData') ?? null,
-    permissions: (yMap.get('permissions') as Entity['permissions']) ?? {
-      default: 'observer',
-      seats: {},
-    },
+    ruleData: readRuleData(yMap),
+    permissions: readPermissions(yMap),
+  }
+}
+
+/** Write permissions as a nested Y.Map structure */
+function writePermissions(entityYMap: Y.Map<unknown>, permissions: EntityPermissions) {
+  const permYMap = new Y.Map<unknown>()
+  entityYMap.set('permissions', permYMap)
+  permYMap.set('default', permissions.default)
+  const seatsYMap = new Y.Map<unknown>()
+  permYMap.set('seats', seatsYMap)
+  for (const [seatId, level] of Object.entries(permissions.seats)) {
+    seatsYMap.set(seatId, level)
+  }
+}
+
+/** Write ruleData as a nested Y.Map structure */
+function writeRuleData(entityYMap: Y.Map<unknown>, ruleData: unknown) {
+  const ruleYMap = new Y.Map<unknown>()
+  entityYMap.set('ruleData', ruleYMap)
+  if (ruleData && typeof ruleData === 'object') {
+    for (const [key, value] of Object.entries(ruleData as Record<string, unknown>)) {
+      ruleYMap.set(key, value)
+    }
   }
 }
 
@@ -31,8 +84,42 @@ function setYMapFields(yMap: Y.Map<unknown>, entity: Entity) {
   yMap.set('size', entity.size)
   if (entity.blueprintId) yMap.set('blueprintId', entity.blueprintId)
   yMap.set('notes', entity.notes)
-  yMap.set('ruleData', entity.ruleData)
-  yMap.set('permissions', entity.permissions)
+  writeRuleData(yMap, entity.ruleData)
+  writePermissions(yMap, entity.permissions)
+}
+
+/** Update permissions Y.Map in place (merge into existing nested structure) */
+function updatePermissions(entityYMap: Y.Map<unknown>, permissions: EntityPermissions) {
+  const permYMap = entityYMap.get('permissions')
+  if (permYMap instanceof Y.Map) {
+    permYMap.set('default', permissions.default)
+    const seatsYMap = permYMap.get('seats')
+    if (seatsYMap instanceof Y.Map) {
+      // Clear existing seats and set new ones
+      seatsYMap.forEach((_v, k) => seatsYMap.delete(k))
+      for (const [seatId, level] of Object.entries(permissions.seats)) {
+        seatsYMap.set(seatId, level)
+      }
+    }
+  } else {
+    // Fallback: create from scratch
+    writePermissions(entityYMap, permissions)
+  }
+}
+
+/** Update ruleData Y.Map in place (merge top-level keys) */
+function updateRuleData(entityYMap: Y.Map<unknown>, ruleData: unknown) {
+  const ruleYMap = entityYMap.get('ruleData')
+  if (ruleYMap instanceof Y.Map) {
+    if (ruleData && typeof ruleData === 'object') {
+      for (const [key, value] of Object.entries(ruleData as Record<string, unknown>)) {
+        ruleYMap.set(key, value)
+      }
+    }
+  } else {
+    // Fallback: create from scratch
+    writeRuleData(entityYMap, ruleData)
+  }
 }
 
 export function useEntities(world: WorldMaps, currentSceneId: string | null, yDoc: Y.Doc) {
@@ -42,18 +129,10 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
   const rebuild = useCallback(() => {
     const result: EntityWithSource[] = []
 
-    // Party (PCs) — nested Y.Maps
-    world.party.forEach((yMap) => {
+    // Roster (cross-scene persistent characters) — nested Y.Maps
+    world.roster.forEach((yMap) => {
       if (yMap instanceof Y.Map) {
-        result.push({ ...readYMapEntity(yMap), _source: 'party' })
-      }
-    })
-
-    // Prepared (GM staging) — plain objects
-    world.prepared.forEach((val) => {
-      const entity = val as Entity
-      if (entity && entity.id) {
-        result.push({ ...entity, _source: 'prepared' })
+        result.push({ ...readYMapEntity(yMap), _source: 'roster' })
       }
     })
 
@@ -79,11 +158,8 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
   useEffect(() => {
     rebuild()
 
-    // Party: observeDeep because values are nested Y.Maps
-    world.party.observeDeep(rebuild)
-
-    // Prepared: observe (plain objects, top-level changes only)
-    world.prepared.observe(rebuild)
+    // Roster: observeDeep because values are nested Y.Maps
+    world.roster.observeDeep(rebuild)
 
     // Current scene entities
     let sceneEntitiesMap: Y.Map<unknown> | null = null
@@ -98,8 +174,7 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
     }
 
     return () => {
-      world.party.unobserveDeep(rebuild)
-      world.prepared.unobserve(rebuild)
+      world.roster.unobserveDeep(rebuild)
       if (sceneEntitiesMap instanceof Y.Map) {
         sceneEntitiesMap.unobserve(rebuild)
       }
@@ -108,12 +183,12 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
 
   // --- CRUD ---
 
-  /** Add PC to party (nested Y.Map) */
-  const addPartyEntity = useCallback(
+  /** Add entity to roster (nested Y.Map for field-level CRDT) */
+  const addRosterEntity = useCallback(
     (entity: Entity) => {
       yDoc.transact(() => {
         const yMap = new Y.Map<unknown>()
-        world.party.set(entity.id, yMap)
+        world.roster.set(entity.id, yMap)
         setYMapFields(yMap, entity)
       })
     },
@@ -135,32 +210,23 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
     [world, currentSceneId],
   )
 
-  /** Add entity to prepared (plain object) */
-  const addPreparedEntity = useCallback(
-    (entity: Entity) => {
-      world.prepared.set(entity.id, entity)
-    },
-    [world],
-  )
-
   /** Update entity (auto-detects source) */
   const updateEntity = useCallback(
     (id: string, updates: Partial<Entity>) => {
-      // Check party first (nested Y.Map)
-      const partyYMap = world.party.get(id)
-      if (partyYMap instanceof Y.Map) {
+      // Check roster first (nested Y.Map)
+      const rosterYMap = world.roster.get(id)
+      if (rosterYMap instanceof Y.Map) {
         yDoc.transact(() => {
           for (const [key, value] of Object.entries(updates)) {
-            partyYMap.set(key, value)
+            if (key === 'permissions') {
+              updatePermissions(rosterYMap, value as EntityPermissions)
+            } else if (key === 'ruleData') {
+              updateRuleData(rosterYMap, value)
+            } else {
+              rosterYMap.set(key, value)
+            }
           }
         })
-        return
-      }
-
-      // Check prepared
-      const preparedEntity = world.prepared.get(id) as Entity | undefined
-      if (preparedEntity) {
-        world.prepared.set(id, { ...preparedEntity, ...updates })
         return
       }
 
@@ -185,12 +251,8 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
   /** Delete entity from wherever it lives */
   const deleteEntity = useCallback(
     (id: string) => {
-      if (world.party.has(id)) {
-        world.party.delete(id)
-        return
-      }
-      if (world.prepared.has(id)) {
-        world.prepared.delete(id)
+      if (world.roster.has(id)) {
+        world.roster.delete(id)
         return
       }
       if (currentSceneId) {
@@ -215,8 +277,8 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
     [entities],
   )
 
-  /** Promote entity from scene to prepared (GM collection) */
-  const promoteToGM = useCallback(
+  /** Promote entity from scene to roster (cross-scene persistent) */
+  const promoteToRoster = useCallback(
     (id: string) => {
       if (!currentSceneId) return
       const sceneMap = world.scenes.get(currentSceneId)
@@ -226,7 +288,9 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
       const entity = sceneEntities.get(id)
       if (!entity) return
       yDoc.transact(() => {
-        world.prepared.set(id, entity)
+        const yMap = new Y.Map<unknown>()
+        world.roster.set(id, yMap)
+        setYMapFields(yMap, entity)
         sceneEntities.delete(id)
       })
     },
@@ -235,12 +299,11 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
 
   return {
     entities: entities as Entity[],
-    addPartyEntity,
+    addRosterEntity,
     addSceneEntity,
-    addPreparedEntity,
     updateEntity,
     deleteEntity,
     getEntity,
-    promoteToGM,
+    promoteToRoster,
   }
 }

--- a/src/yjs/useWorld.ts
+++ b/src/yjs/useWorld.ts
@@ -3,39 +3,30 @@ import { useMemo } from 'react'
 import * as Y from 'yjs'
 
 export interface WorldMaps {
-  /** Top-level world map */
-  world: Y.Map<unknown>
   /** Y.Map of sceneId → Y.Map (each scene contains config keys, 'entities' Y.Map, 'tokens' Y.Map) */
   scenes: Y.Map<Y.Map<unknown>>
-  /** Y.Map of entityId → Y.Map (PC entities, field-level CRDT) */
-  party: Y.Map<Y.Map<unknown>>
-  /** Y.Map of entityId → plain Entity object (GM staging area) */
-  prepared: Y.Map<unknown>
+  /** Y.Map of entityId → Y.Map (cross-scene persistent characters, field-level CRDT) */
+  roster: Y.Map<Y.Map<unknown>>
   /** Y.Map of blueprintId → plain Blueprint object */
   blueprints: Y.Map<unknown>
   /** Y.Map of seatId → plain Seat object */
   seats: Y.Map<unknown>
-  /** Y.Array of ChatMessage objects */
-  chat: Y.Array<unknown>
   /** Y.Map of room-level state (mode, activeSceneId, etc.) */
   room: Y.Map<unknown>
 }
 
 /**
  * Create WorldMaps using top-level shared types.
- * Uses yDoc.getMap/getArray which are guaranteed to return the same instance
+ * Uses yDoc.getMap which is guaranteed to return the same instance
  * across all clients, avoiding race conditions from nested Y.Map creation.
  */
 export function createWorldMaps(yDoc: Y.Doc): WorldMaps {
   return {
-    world: yDoc.getMap('world'),
-    scenes: yDoc.getMap('world:scenes') as Y.Map<Y.Map<unknown>>,
-    party: yDoc.getMap('world:party') as Y.Map<Y.Map<unknown>>,
-    prepared: yDoc.getMap('world:prepared'),
-    blueprints: yDoc.getMap('world:blueprints'),
-    seats: yDoc.getMap('world:seats'),
-    chat: yDoc.getArray('world:chat') as Y.Array<unknown>,
-    room: yDoc.getMap('world:room'),
+    scenes: yDoc.getMap('scenes') as Y.Map<Y.Map<unknown>>,
+    roster: yDoc.getMap('roster') as Y.Map<Y.Map<unknown>>,
+    blueprints: yDoc.getMap('blueprints'),
+    seats: yDoc.getMap('seats'),
+    room: yDoc.getMap('room'),
   }
 }
 


### PR DESCRIPTION
## Summary

- 删除死代码 `world:chat`（未使用的 Y.Array）
- 修复 `useShowcase` 的 room map 引用（`'room'` → 统一使用 WorldMaps room）
- 移除所有顶层 Y.Doc key 的 `world:` 前缀，清理空置的 `world` map
- 合并 `party` + `prepared` 为统一的 `roster` 容器
- 将 roster 中的 `permissions` 和 `ruleData` 转为嵌套 Y.Map，支持字段级 CRDT 并发合并
- 新增 8 个测试覆盖嵌套 Y.Map 存储、读回、更新及并发编辑

## Test Plan

- [x] 158 tests passing (vitest)
- [x] TypeScript 编译零错误
- [x] ESLint + Prettier 通过（pre-commit hook）
- [x] 并发权限编辑测试验证不同 seat 的独立合并