### PR TITLE
refactor: unify entity system with single-source store and permissions model

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,15 +45,17 @@ function RoomSession({ roomId }: { roomId: string }) {
     leaveSeat,
     updateSeat,
   } = useIdentity(world.seats, awareness)
-  const { room, setActiveScene, setCombatScene, enterCombat, exitCombat } = useRoom(world.room)
-  const { scenes, addScene, updateScene, deleteScene, getScene } = useScenes(world.scenes, yDoc)
-
-  const combatSceneId = room.mode === 'combat' ? room.combatSceneId : null
-  const { entities, addSceneEntity, updateEntity, deleteEntity, getEntity } = useEntities(
-    world,
-    room.activeSceneId,
+  const { room, setActiveScene } = useRoom(world.room)
+  const { scenes, addScene, updateScene, deleteScene, getScene, setCombatActive } = useScenes(
+    world.scenes,
     yDoc,
   )
+
+  const { entities, addEntity, updateEntity, deleteEntity, getEntity } = useEntities(world, yDoc)
+
+  const activeScene = getScene(room.activeSceneId)
+  const isCombat = activeScene?.combatActive ?? false
+  const combatSceneId = isCombat ? room.activeSceneId : null
   const { tokens, addToken, updateToken, deleteToken, getToken } = useSceneTokens(
     world,
     combatSceneId,
@@ -119,9 +121,6 @@ function RoomSession({ roomId }: { roomId: string }) {
   }
 
   const isGM = mySeat.role === 'GM'
-  const isCombat = room.mode === 'combat'
-  const activeScene = getScene(room.activeSceneId)
-  const combatScene = getScene(room.combatSceneId)
 
   // Derive entity data
   const activeEntity = getEntity(mySeat.activeCharacterId ?? null)
@@ -192,8 +191,9 @@ function RoomSession({ roomId }: { roomId: string }) {
       notes: '',
       ruleData: null,
       permissions: defaultNPCPermissions(),
+      persistent: false,
     }
-    addSceneEntity(newEntity)
+    addEntity(newEntity)
     setInspectedCharacterId(newEntity.id)
     setBgContextMenu(null)
   }
@@ -202,7 +202,7 @@ function RoomSession({ roomId }: { roomId: string }) {
     <div>
       {isCombat ? (
         <CombatViewer
-          scene={combatScene}
+          scene={activeScene}
           tokens={tokens}
           getEntity={getEntity}
           mySeatId={mySeatId}
@@ -260,13 +260,13 @@ function RoomSession({ roomId }: { roomId: string }) {
       {isGM && (
         <BottomDock
           scenes={scenes}
-          combatSceneId={room.combatSceneId}
-          onSetCombatScene={setCombatScene}
+          activeSceneId={room.activeSceneId}
+          onSelectScene={setActiveScene}
           onAddScene={addScene}
           onDeleteScene={deleteScene}
           blueprints={world.blueprints}
           entities={entities}
-          onAddSceneEntity={addSceneEntity}
+          onAddEntity={addEntity}
           isCombat={isCombat}
           selectedToken={getToken(selectedTokenId)}
           onAddToken={addToken}
@@ -285,10 +285,12 @@ function RoomSession({ roomId }: { roomId: string }) {
       {isGM && (
         <GmToolbar
           scenes={scenes}
-          room={room}
+          activeSceneId={room.activeSceneId}
+          isCombat={isCombat}
           onSelectScene={setActiveScene}
-          onEnterCombat={enterCombat}
-          onExitCombat={exitCombat}
+          onToggleCombat={() => {
+            if (room.activeSceneId) setCombatActive(room.activeSceneId, !isCombat)
+          }}
           onAddScene={addScene}
           onUpdateScene={updateScene}
           onDeleteScene={deleteScene}

--- a/src/__test-utils__/fixtures.ts
+++ b/src/__test-utils__/fixtures.ts
@@ -10,6 +10,7 @@ export function makeEntity(overrides?: Partial<Entity>): Entity {
     notes: '',
     ruleData: null,
     permissions: { default: 'observer', seats: {} },
+    persistent: false,
     ...overrides,
   }
 }
@@ -20,7 +21,7 @@ export function makeToken(overrides?: Partial<MapToken>): MapToken {
     x: 100,
     y: 200,
     size: 1,
-    gmOnly: false,
+    permissions: { default: 'observer', seats: {} },
     ...overrides,
   }
 }

--- a/src/__test-utils__/yjs-helpers.ts
+++ b/src/__test-utils__/yjs-helpers.ts
@@ -11,20 +11,6 @@ export function createTestDoc(): { yDoc: Y.Doc } & WorldMaps {
   return { yDoc, ...createWorldMaps(yDoc) }
 }
 
-function buildWorldMaps(yDoc: Y.Doc): WorldMaps {
-  const world = yDoc.getMap('world')
-  return {
-    world,
-    scenes: world.get('scenes') as Y.Map<Y.Map<unknown>>,
-    party: world.get('party') as Y.Map<Y.Map<unknown>>,
-    prepared: world.get('prepared') as Y.Map<unknown>,
-    blueprints: world.get('blueprints') as Y.Map<unknown>,
-    seats: world.get('seats') as Y.Map<unknown>,
-    chat: world.get('chat') as Y.Array<unknown>,
-    room: world.get('room') as Y.Map<unknown>,
-  }
-}
-
 /**
  * Create two Y.Docs with bidirectional sync via Y.applyUpdate.
  * Simulates two clients connected to the same room without real WebSocket.
@@ -42,32 +28,16 @@ export function createSyncedPair(): {
   doc1.on('update', (update: Uint8Array) => Y.applyUpdate(doc2, update))
   doc2.on('update', (update: Uint8Array) => Y.applyUpdate(doc1, update))
 
-  // Initialize world structure on doc1 (auto-syncs to doc2)
-  const world1Root = doc1.getMap('world')
-  doc1.transact(() => {
-    world1Root.set('scenes', new Y.Map())
-    world1Root.set('party', new Y.Map())
-    world1Root.set('prepared', new Y.Map())
-    world1Root.set('blueprints', new Y.Map())
-    world1Root.set('seats', new Y.Map())
-    world1Root.set('chat', new Y.Array())
-    world1Root.set('room', new Y.Map())
-  })
-
   return {
     doc1,
     doc2,
-    world1: buildWorldMaps(doc1),
-    world2: buildWorldMaps(doc2),
+    world1: createWorldMaps(doc1),
+    world2: createWorldMaps(doc2),
   }
 }
 
-/** Add a scene with entities + tokens sub-maps to a scenes Y.Map */
-export function addSceneToDoc(
-  scenes: Y.Map<Y.Map<unknown>>,
-  yDoc: Y.Doc,
-  sceneId: string,
-) {
+/** Add a scene with entityIds + tokens sub-maps to a scenes Y.Map */
+export function addSceneToDoc(scenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc, sceneId: string) {
   yDoc.transact(() => {
     const sceneMap = new Y.Map<unknown>()
     scenes.set(sceneId, sceneMap)
@@ -81,7 +51,9 @@ export function addSceneToDoc(
     sceneMap.set('gridOffsetX', 0)
     sceneMap.set('gridOffsetY', 0)
     sceneMap.set('sortOrder', 0)
-    sceneMap.set('entities', new Y.Map())
+    sceneMap.set('combatActive', false)
+    sceneMap.set('battleMapUrl', '')
+    sceneMap.set('entityIds', new Y.Map())
     sceneMap.set('tokens', new Y.Map())
   })
 }

--- a/src/combat/MapToken.tsx
+++ b/src/combat/MapToken.tsx
@@ -6,7 +6,7 @@ interface MapTokenProps {
   entity: Entity | null
   pixelSize: number
   selected: boolean
-  gmOnly: boolean
+  isHidden: boolean
   dragging: boolean
   dragX?: number
   dragY?: number
@@ -19,7 +19,7 @@ export function MapToken({
   entity,
   pixelSize,
   selected,
-  gmOnly,
+  isHidden,
   dragging,
   dragX,
   dragY,
@@ -64,8 +64,8 @@ export function MapToken({
           boxShadow: selected
             ? `0 0 0 2px ${color}, 0 0 16px ${color}66`
             : `0 2px 8px rgba(0,0,0,0.4)`,
-          opacity: gmOnly ? 0.5 : 1,
-          borderStyle: gmOnly ? 'dashed' : 'solid',
+          opacity: isHidden ? 0.5 : 1,
+          borderStyle: isHidden ? 'dashed' : 'solid',
           boxSizing: 'border-box',
           transition: 'border-color 0.15s, box-shadow 0.15s',
         }}

--- a/src/combat/TokenLayer.tsx
+++ b/src/combat/TokenLayer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTransformContext } from 'react-zoom-pan-pinch'
 import type { MapToken as MapTokenType, Entity } from '../shared/entityTypes'
-import { canSee } from '../shared/permissions'
+import { getEffectivePermissions, canSee } from '../shared/permissions'
 import type { Scene } from '../yjs/useScenes'
 import { MapToken } from './MapToken'
 import { canDragToken, screenToMap, snapToGrid } from './combatUtils'
@@ -40,15 +40,10 @@ export function TokenLayer({
   const dragRef = useRef<DragState | null>(null)
   const didDragRef = useRef(false)
 
-  // Filter tokens by visibility
+  // Filter tokens by visibility using unified permissions
   const visibleTokens = tokens.filter((t) => {
-    if (role === 'GM') return true
-    if (t.gmOnly) return false
-    if (t.entityId) {
-      const entity = getEntity(t.entityId)
-      if (entity && !canSee(entity, mySeatId, role)) return false
-    }
-    return true
+    const perms = getEffectivePermissions(t, getEntity)
+    return canSee(perms, mySeatId, role)
   })
 
   const handlePointerDown = useCallback(
@@ -196,7 +191,7 @@ export function TokenLayer({
             entity={entity}
             pixelSize={token.size * scene.gridSize}
             selected={token.id === selectedTokenId}
-            gmOnly={token.gmOnly && role === 'GM'}
+            isHidden={getEffectivePermissions(token, getEntity).default === 'none' && role === 'GM'}
             dragging={isDragging ?? false}
             dragX={isDragging ? drag?.currentMapX : undefined}
             dragY={isDragging ? drag?.currentMapY : undefined}

--- a/src/combat/combatUtils.ts
+++ b/src/combat/combatUtils.ts
@@ -35,5 +35,5 @@ export function screenToMap(
 export function canDragToken(role: 'GM' | 'PL', entity: Entity | null, mySeatId: string): boolean {
   if (role === 'GM') return true
   if (!entity) return false
-  return canEdit(entity, mySeatId, role)
+  return canEdit(entity.permissions, mySeatId, role)
 }

--- a/src/dock/BottomDock.tsx
+++ b/src/dock/BottomDock.tsx
@@ -14,8 +14,8 @@ type TabId = 'maps' | 'tokens' | 'handouts'
 
 interface BottomDockProps {
   scenes: Scene[]
-  combatSceneId: string | null
-  onSetCombatScene: (sceneId: string) => void
+  activeSceneId: string | null
+  onSelectScene: (sceneId: string) => void
   onAddScene: (scene: Scene) => void
   onDeleteScene: (id: string) => void
 
@@ -28,7 +28,7 @@ interface BottomDockProps {
   onShowcaseHandout: (asset: HandoutAsset) => void
 
   entities: Entity[]
-  onAddSceneEntity: (entity: Entity) => void
+  onAddEntity: (entity: Entity) => void
   isCombat: boolean
 
   selectedToken: MapToken | null
@@ -40,8 +40,8 @@ interface BottomDockProps {
 
 export function BottomDock({
   scenes,
-  combatSceneId,
-  onSetCombatScene,
+  activeSceneId,
+  onSelectScene,
   onAddScene,
   onDeleteScene,
   blueprints: blueprintsYMap,
@@ -51,7 +51,7 @@ export function BottomDock({
   onDeleteHandoutAsset,
   onShowcaseHandout,
   entities,
-  onAddSceneEntity,
+  onAddEntity,
   isCombat,
   selectedToken,
   onAddToken,
@@ -131,9 +131,10 @@ export function BottomDock({
       notes: '',
       ruleData: bp.defaultRuleData ?? null,
       permissions: defaultNPCPermissions(),
+      persistent: false,
       blueprintId: bp.id,
     }
-    onAddSceneEntity(entity)
+    onAddEntity(entity)
     return entity
   }
 
@@ -145,7 +146,7 @@ export function BottomDock({
       x: 200,
       y: 200,
       size: bp.defaultSize,
-      gmOnly: false,
+      permissions: defaultNPCPermissions(),
     }
     onAddToken(token)
     onSelectToken(token.id)
@@ -161,9 +162,11 @@ export function BottomDock({
     onSelectToken(null)
   }
 
-  const handleToggleGmOnly = () => {
+  const handleToggleVisibility = () => {
     if (!selectedToken) return
-    onUpdateToken(selectedToken.id, { gmOnly: !selectedToken.gmOnly })
+    const isHidden = selectedToken.permissions.default === 'none'
+    const newPerms = isHidden ? defaultNPCPermissions() : { default: 'none' as const, seats: {} }
+    onUpdateToken(selectedToken.id, { permissions: newPerms })
   }
 
   const tabBtnStyle = (isActive: boolean): React.CSSProperties => ({
@@ -235,8 +238,8 @@ export function BottomDock({
           {activeTab === 'maps' && (
             <MapDockTab
               scenes={scenes}
-              combatSceneId={combatSceneId}
-              onSetCombatScene={onSetCombatScene}
+              activeSceneId={activeSceneId}
+              onSelectScene={onSelectScene}
               onAddScene={onAddScene}
               onDeleteScene={onDeleteScene}
             />
@@ -342,40 +345,44 @@ export function BottomDock({
         )}
 
         {/* Action: Toggle visibility */}
-        {selectedToken && (
-          <button
-            onClick={handleToggleGmOnly}
-            style={{
-              ...actionBtnStyle,
-              color: selectedToken.gmOnly ? '#fbbf24' : '#a0a0a0',
-            }}
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              {selectedToken.gmOnly ? (
-                <>
-                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-                  <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-                  <line x1="1" y1="1" x2="23" y2="23" />
-                </>
-              ) : (
-                <>
-                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                  <circle cx="12" cy="12" r="3" />
-                </>
-              )}
-            </svg>
-            {selectedToken.gmOnly ? 'Hidden' : 'Visible'}
-          </button>
-        )}
+        {selectedToken &&
+          (() => {
+            const isHidden = selectedToken.permissions.default === 'none'
+            return (
+              <button
+                onClick={handleToggleVisibility}
+                style={{
+                  ...actionBtnStyle,
+                  color: isHidden ? '#fbbf24' : '#a0a0a0',
+                }}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  {isHidden ? (
+                    <>
+                      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                      <line x1="1" y1="1" x2="23" y2="23" />
+                    </>
+                  ) : (
+                    <>
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                      <circle cx="12" cy="12" r="3" />
+                    </>
+                  )}
+                </svg>
+                {isHidden ? 'Hidden' : 'Visible'}
+              </button>
+            )
+          })()}
       </div>
     </div>
   )

--- a/src/dock/MapDockTab.tsx
+++ b/src/dock/MapDockTab.tsx
@@ -5,16 +5,16 @@ import { generateTokenId } from '../shared/idUtils'
 
 interface MapDockTabProps {
   scenes: Scene[]
-  combatSceneId: string | null
-  onSetCombatScene: (sceneId: string) => void
+  activeSceneId: string | null
+  onSelectScene: (sceneId: string) => void
   onAddScene: (scene: Scene) => void
   onDeleteScene: (id: string) => void
 }
 
 export function MapDockTab({
   scenes,
-  combatSceneId,
-  onSetCombatScene,
+  activeSceneId,
+  onSelectScene,
   onAddScene,
   onDeleteScene,
 }: MapDockTabProps) {
@@ -43,9 +43,11 @@ export function MapDockTab({
         gridOffsetX: 0,
         gridOffsetY: 0,
         sortOrder: scenes.length,
+        combatActive: false,
+        battleMapUrl: '',
       }
       onAddScene(scene)
-      onSetCombatScene(scene.id)
+      onSelectScene(scene.id)
     } finally {
       setUploading(false)
     }
@@ -69,7 +71,7 @@ export function MapDockTab({
         }}
       >
         {scenes.map((scene) => {
-          const isActive = scene.id === combatSceneId
+          const isActive = scene.id === activeSceneId
           const isHovered = hoveredId === scene.id
           return (
             <div
@@ -83,7 +85,7 @@ export function MapDockTab({
                 boxShadow: isActive ? '0 0 12px rgba(59,130,246,0.3)' : 'none',
                 transition: 'border-color 0.15s, box-shadow 0.15s',
               }}
-              onClick={() => onSetCombatScene(scene.id)}
+              onClick={() => onSelectScene(scene.id)}
               onMouseEnter={() => setHoveredId(scene.id)}
               onMouseLeave={() => setHoveredId(null)}
             >

--- a/src/entities/__tests__/useEntities.sync.test.ts
+++ b/src/entities/__tests__/useEntities.sync.test.ts
@@ -1,45 +1,30 @@
 import { renderHook, act } from '@testing-library/react'
 import { useEntities } from '../useEntities'
-import { createSyncedPair, addSceneToDoc } from '../../__test-utils__/yjs-helpers'
+import { createSyncedPair } from '../../__test-utils__/yjs-helpers'
 import { makeEntity } from '../../__test-utils__/fixtures'
 
 describe('useEntities — multi-client sync', () => {
-  const sceneId = 'scene-1'
-
-  function setup(currentSceneId: string | null = sceneId) {
+  function setup() {
     const { doc1, doc2, world1, world2 } = createSyncedPair()
-    // Create scene on doc1 (auto-syncs to doc2)
-    addSceneToDoc(world1.scenes, doc1, sceneId)
-    const hook1 = renderHook(() => useEntities(world1, currentSceneId, doc1))
-    const hook2 = renderHook(() => useEntities(world2, currentSceneId, doc2))
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
     return { doc1, doc2, world1, world2, hook1, hook2 }
   }
 
-  it('Client A adds party entity → Client B sees it', () => {
+  it('Client A adds entity → Client B sees it', () => {
     const { hook1, hook2 } = setup()
     const entity = makeEntity({ id: 'pc-1', name: 'Fighter' })
 
-    act(() => hook1.result.current.addPartyEntity(entity))
+    act(() => hook1.result.current.addEntity(entity))
 
     const found = hook2.result.current.entities.find((e) => e.id === 'pc-1')
     expect(found).toBeDefined()
     expect(found?.name).toBe('Fighter')
   })
 
-  it('Client A adds scene entity → Client B sees it', () => {
-    const { hook1, hook2 } = setup()
-    const entity = makeEntity({ id: 'npc-1', name: 'Goblin' })
-
-    act(() => hook1.result.current.addSceneEntity(entity))
-
-    const found = hook2.result.current.entities.find((e) => e.id === 'npc-1')
-    expect(found).toBeDefined()
-    expect(found?.name).toBe('Goblin')
-  })
-
   it('Client A updates entity name → Client B syncs', () => {
     const { hook1, hook2 } = setup()
-    act(() => hook1.result.current.addPartyEntity(makeEntity({ id: 'pc-1', name: 'Fighter' })))
+    act(() => hook1.result.current.addEntity(makeEntity({ id: 'pc-1', name: 'Fighter' })))
 
     act(() => hook1.result.current.updateEntity('pc-1', { name: 'Paladin' }))
 
@@ -48,7 +33,7 @@ describe('useEntities — multi-client sync', () => {
 
   it('Client A deletes entity → Client B syncs', () => {
     const { hook1, hook2 } = setup()
-    act(() => hook1.result.current.addPartyEntity(makeEntity({ id: 'pc-1' })))
+    act(() => hook1.result.current.addEntity(makeEntity({ id: 'pc-1' })))
     expect(hook2.result.current.entities.find((e) => e.id === 'pc-1')).toBeDefined()
 
     act(() => hook1.result.current.deleteEntity('pc-1'))
@@ -57,12 +42,10 @@ describe('useEntities — multi-client sync', () => {
     expect(hook2.result.current.entities.find((e) => e.id === 'pc-1')).toBeUndefined()
   })
 
-  it('concurrent updates to different fields on party entity → both merge', () => {
+  it('concurrent updates to different fields → both merge', () => {
     const { hook1, hook2 } = setup()
     act(() =>
-      hook1.result.current.addPartyEntity(
-        makeEntity({ id: 'pc-1', name: 'Fighter', color: '#3b82f6' }),
-      ),
+      hook1.result.current.addEntity(makeEntity({ id: 'pc-1', name: 'Fighter', color: '#3b82f6' })),
     )
 
     // Doc1 updates name, Doc2 updates color — different Y.Map keys

--- a/src/entities/__tests__/useEntities.test.ts
+++ b/src/entities/__tests__/useEntities.test.ts
@@ -4,24 +4,10 @@ import { useEntities } from '../useEntities'
 import { createTestDoc } from '../../__test-utils__/yjs-helpers'
 import { makeEntity } from '../../__test-utils__/fixtures'
 
-/** Helper: create a scene with entities + tokens sub-maps */
-function addSceneToDoc(scenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc, sceneId: string) {
-  yDoc.transact(() => {
-    const sceneMap = new Y.Map<unknown>()
-    scenes.set(sceneId, sceneMap)
-    sceneMap.set('name', 'Test Scene')
-    sceneMap.set('entities', new Y.Map())
-    sceneMap.set('tokens', new Y.Map())
-  })
-}
-
 describe('useEntities', () => {
-  const sceneId = 'scene-1'
-
-  function setup(currentSceneId: string | null = sceneId) {
+  function setup() {
     const { yDoc, ...world } = createTestDoc()
-    addSceneToDoc(world.scenes as Y.Map<Y.Map<unknown>>, yDoc, sceneId)
-    const hook = renderHook(() => useEntities(world, currentSceneId, yDoc))
+    const hook = renderHook(() => useEntities(world, yDoc))
     return { yDoc, world, hook }
   }
 
@@ -32,57 +18,35 @@ describe('useEntities', () => {
     expect(hook.result.current.entities).toEqual([])
   })
 
-  // ── addRosterEntity ───────────────────────────────────────
+  // ── addEntity ───────────────────────────────────────────────
 
-  it('adds a roster entity', () => {
+  it('adds an entity', () => {
     const { hook } = setup()
     const entity = makeEntity({ id: 'pc-1', name: 'Fighter' })
 
-    act(() => hook.result.current.addRosterEntity(entity))
+    act(() => hook.result.current.addEntity(entity))
 
     const found = hook.result.current.entities.find((e) => e.id === 'pc-1')
     expect(found).toBeDefined()
     expect(found?.name).toBe('Fighter')
   })
 
-  // ── addSceneEntity ────────────────────────────────────────
+  // ── updateEntity ──────────────────────────────────────────────
 
-  it('adds a scene entity', () => {
+  it('updates an entity', () => {
     const { hook } = setup()
-    const entity = makeEntity({ id: 'se-1', name: 'Chest' })
-
-    act(() => hook.result.current.addSceneEntity(entity))
-
-    const found = hook.result.current.entities.find((e) => e.id === 'se-1')
-    expect(found).toBeDefined()
-    expect(found?.name).toBe('Chest')
-  })
-
-  // ── updateEntity (auto-detect source) ───────────────────────
-
-  it('updates a roster entity', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1', name: 'Fighter' })))
+    act(() => hook.result.current.addEntity(makeEntity({ id: 'pc-1', name: 'Fighter' })))
 
     act(() => hook.result.current.updateEntity('pc-1', { name: 'Paladin' }))
 
     expect(hook.result.current.entities.find((e) => e.id === 'pc-1')?.name).toBe('Paladin')
   })
 
-  it('updates a scene entity', () => {
+  // ── deleteEntity ──────────────────────────────────────────────
+
+  it('deletes an entity', () => {
     const { hook } = setup()
-    act(() => hook.result.current.addSceneEntity(makeEntity({ id: 'se-1', name: 'Chest' })))
-
-    act(() => hook.result.current.updateEntity('se-1', { name: 'Mimic' }))
-
-    expect(hook.result.current.entities.find((e) => e.id === 'se-1')?.name).toBe('Mimic')
-  })
-
-  // ── deleteEntity (auto-detect source) ───────────────────────
-
-  it('deletes a roster entity', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1' })))
+    act(() => hook.result.current.addEntity(makeEntity({ id: 'pc-1' })))
     expect(hook.result.current.entities).toHaveLength(1)
 
     act(() => hook.result.current.deleteEntity('pc-1'))
@@ -90,38 +54,11 @@ describe('useEntities', () => {
     expect(hook.result.current.entities).toHaveLength(0)
   })
 
-  it('deletes a scene entity', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.addSceneEntity(makeEntity({ id: 'se-1' })))
-
-    act(() => hook.result.current.deleteEntity('se-1'))
-
-    expect(hook.result.current.entities).toHaveLength(0)
-  })
-
-  // ── promoteToRoster ────────────────────────────────────────
-
-  it('promotes scene entity to roster', () => {
-    const { hook, world } = setup()
-    act(() => hook.result.current.addSceneEntity(makeEntity({ id: 'se-1', name: 'Trap' })))
-
-    act(() => hook.result.current.promoteToRoster('se-1'))
-
-    // Should now be in roster, not in scene entities
-    expect(world.roster.has('se-1')).toBe(true)
-    const rosterYMap = world.roster.get('se-1')
-    expect(rosterYMap).toBeInstanceOf(Y.Map)
-    expect((rosterYMap as Y.Map<unknown>).get('name')).toBe('Trap')
-    const sceneMap = world.scenes.get(sceneId)
-    const sceneEntities = (sceneMap as Y.Map<unknown>).get('entities') as Y.Map<unknown>
-    expect(sceneEntities.has('se-1')).toBe(false)
-  })
-
   // ── getEntity ───────────────────────────────────────────────
 
   it('returns entity by id', () => {
     const { hook } = setup()
-    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1', name: 'Rogue' })))
+    act(() => hook.result.current.addEntity(makeEntity({ id: 'pc-1', name: 'Rogue' })))
 
     expect(hook.result.current.getEntity('pc-1')?.name).toBe('Rogue')
   })
@@ -136,6 +73,22 @@ describe('useEntities', () => {
     expect(hook.result.current.getEntity(null)).toBeNull()
   })
 
+  // ── persistent flag ───────────────────────────────────────────
+
+  it('stores and reads back persistent flag', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addEntity(makeEntity({ id: 'pc-1', persistent: true })))
+
+    expect(hook.result.current.getEntity('pc-1')?.persistent).toBe(true)
+  })
+
+  it('defaults persistent to false', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addEntity(makeEntity({ id: 'pc-1' })))
+
+    expect(hook.result.current.getEntity('pc-1')?.persistent).toBe(false)
+  })
+
   // ── nested Y.Map: permissions & ruleData ───────────────────
 
   it('stores permissions as nested Y.Map', () => {
@@ -145,9 +98,9 @@ describe('useEntities', () => {
       permissions: { default: 'observer', seats: { 'seat-1': 'owner' } },
     })
 
-    act(() => hook.result.current.addRosterEntity(entity))
+    act(() => hook.result.current.addEntity(entity))
 
-    const yMap = world.roster.get('pc-1') as Y.Map<unknown>
+    const yMap = world.entities.get('pc-1') as Y.Map<unknown>
     const permYMap = yMap.get('permissions')
     expect(permYMap).toBeInstanceOf(Y.Map)
     expect((permYMap as Y.Map<unknown>).get('default')).toBe('observer')
@@ -163,9 +116,9 @@ describe('useEntities', () => {
       ruleData: { kind: 'pc', level: 3, resources: { hp: { cur: 10, max: 10 } } },
     })
 
-    act(() => hook.result.current.addRosterEntity(entity))
+    act(() => hook.result.current.addEntity(entity))
 
-    const yMap = world.roster.get('pc-1') as Y.Map<unknown>
+    const yMap = world.entities.get('pc-1') as Y.Map<unknown>
     const ruleYMap = yMap.get('ruleData')
     expect(ruleYMap).toBeInstanceOf(Y.Map)
     expect((ruleYMap as Y.Map<unknown>).get('kind')).toBe('pc')
@@ -180,7 +133,7 @@ describe('useEntities', () => {
       permissions: { default: 'none', seats: { 'seat-1': 'owner', 'seat-2': 'observer' } },
     })
 
-    act(() => hook.result.current.addRosterEntity(entity))
+    act(() => hook.result.current.addEntity(entity))
 
     const found = hook.result.current.getEntity('pc-1')
     expect(found?.permissions).toEqual({
@@ -196,7 +149,7 @@ describe('useEntities', () => {
       ruleData: { kind: 'pc', level: 3 },
     })
 
-    act(() => hook.result.current.addRosterEntity(entity))
+    act(() => hook.result.current.addEntity(entity))
 
     const found = hook.result.current.getEntity('pc-1')
     expect(found?.ruleData).toEqual({ kind: 'pc', level: 3 })
@@ -204,7 +157,7 @@ describe('useEntities', () => {
 
   it('null ruleData reads back as null', () => {
     const { hook } = setup()
-    act(() => hook.result.current.addRosterEntity(makeEntity({ id: 'pc-1', ruleData: null })))
+    act(() => hook.result.current.addEntity(makeEntity({ id: 'pc-1', ruleData: null })))
 
     expect(hook.result.current.getEntity('pc-1')?.ruleData).toBeNull()
   })
@@ -212,7 +165,7 @@ describe('useEntities', () => {
   it('updates permissions via updateEntity', () => {
     const { hook } = setup()
     act(() =>
-      hook.result.current.addRosterEntity(
+      hook.result.current.addEntity(
         makeEntity({
           id: 'pc-1',
           permissions: { default: 'observer', seats: { 'seat-1': 'owner' } },
@@ -236,7 +189,7 @@ describe('useEntities', () => {
   it('updates ruleData via updateEntity (merges top-level keys)', () => {
     const { hook } = setup()
     act(() =>
-      hook.result.current.addRosterEntity(
+      hook.result.current.addEntity(
         makeEntity({
           id: 'pc-1',
           ruleData: { kind: 'pc', level: 3, resources: { hp: { cur: 10, max: 10 } } },
@@ -266,13 +219,13 @@ describe('useEntities', () => {
     doc1.on('update', (update: Uint8Array) => Y.applyUpdate(doc2, update))
     doc2.on('update', (update: Uint8Array) => Y.applyUpdate(doc1, update))
 
-    const rosterMap1 = doc1.getMap('roster') as Y.Map<Y.Map<unknown>>
-    const rosterMap2 = doc2.getMap('roster') as Y.Map<Y.Map<unknown>>
+    const entitiesMap1 = doc1.getMap('entities') as Y.Map<Y.Map<unknown>>
+    const entitiesMap2 = doc2.getMap('entities') as Y.Map<Y.Map<unknown>>
 
     // Client 1 creates entity
     doc1.transact(() => {
       const yMap = new Y.Map<unknown>()
-      rosterMap1.set('pc-1', yMap)
+      entitiesMap1.set('pc-1', yMap)
       yMap.set('id', 'pc-1')
       yMap.set('name', 'Fighter')
       const permYMap = new Y.Map<unknown>()
@@ -283,13 +236,13 @@ describe('useEntities', () => {
     })
 
     // Client 1 adds seat-1 permission
-    const entity1 = rosterMap1.get('pc-1') as Y.Map<unknown>
+    const entity1 = entitiesMap1.get('pc-1') as Y.Map<unknown>
     const perm1 = entity1.get('permissions') as Y.Map<unknown>
     const seats1 = perm1.get('seats') as Y.Map<unknown>
     seats1.set('seat-1', 'owner')
 
     // Client 2 adds seat-2 permission (concurrently)
-    const entity2 = rosterMap2.get('pc-1') as Y.Map<unknown>
+    const entity2 = entitiesMap2.get('pc-1') as Y.Map<unknown>
     const perm2 = entity2.get('permissions') as Y.Map<unknown>
     const seats2 = perm2.get('seats') as Y.Map<unknown>
     seats2.set('seat-2', 'owner')

--- a/src/entities/useEntities.ts
+++ b/src/entities/useEntities.ts
@@ -4,8 +4,6 @@ import * as Y from 'yjs'
 import type { Entity, EntityPermissions, PermissionLevel } from '../shared/entityTypes'
 import type { WorldMaps } from '../yjs/useWorld'
 
-type EntityWithSource = Entity & { _source: 'roster' | string }
-
 /** Read permissions from a nested Y.Map back to a plain EntityPermissions object */
 function readPermissions(yMap: Y.Map<unknown>): EntityPermissions {
   const permYMap = yMap.get('permissions')
@@ -50,6 +48,7 @@ function readYMapEntity(yMap: Y.Map<unknown>): Entity {
     notes: (yMap.get('notes') as string) ?? '',
     ruleData: readRuleData(yMap),
     permissions: readPermissions(yMap),
+    persistent: (yMap.get('persistent') as boolean) ?? false,
   }
 }
 
@@ -84,6 +83,7 @@ function setYMapFields(yMap: Y.Map<unknown>, entity: Entity) {
   yMap.set('size', entity.size)
   if (entity.blueprintId) yMap.set('blueprintId', entity.blueprintId)
   yMap.set('notes', entity.notes)
+  yMap.set('persistent', entity.persistent)
   writeRuleData(yMap, entity.ruleData)
   writePermissions(yMap, entity.permissions)
 }
@@ -122,150 +122,67 @@ function updateRuleData(entityYMap: Y.Map<unknown>, ruleData: unknown) {
   }
 }
 
-export function useEntities(world: WorldMaps, currentSceneId: string | null, yDoc: Y.Doc) {
-  const [entities, setEntities] = useState<EntityWithSource[]>([])
+export function useEntities(world: WorldMaps, yDoc: Y.Doc) {
+  const [entities, setEntities] = useState<Entity[]>([])
 
-  // Collect entities from all sources
+  // Collect all entities from the single global source
   const rebuild = useCallback(() => {
-    const result: EntityWithSource[] = []
-
-    // Roster (cross-scene persistent characters) — nested Y.Maps
-    world.roster.forEach((yMap) => {
+    const result: Entity[] = []
+    world.entities.forEach((yMap) => {
       if (yMap instanceof Y.Map) {
-        result.push({ ...readYMapEntity(yMap), _source: 'roster' })
+        result.push(readYMapEntity(yMap))
       }
     })
-
-    // Current scene entities — plain objects
-    if (currentSceneId) {
-      const sceneMap = world.scenes.get(currentSceneId)
-      if (sceneMap instanceof Y.Map) {
-        const sceneEntities = sceneMap.get('entities') as Y.Map<Entity> | undefined
-        if (sceneEntities instanceof Y.Map) {
-          sceneEntities.forEach((entity) => {
-            if (entity && entity.id) {
-              result.push({ ...entity, _source: `scene:${currentSceneId}` })
-            }
-          })
-        }
-      }
-    }
-
     setEntities(result)
-  }, [world, currentSceneId])
+  }, [world])
 
-  // Observe all containers
+  // Observe the global entities map
   useEffect(() => {
     rebuild()
-
-    // Roster: observeDeep because values are nested Y.Maps
-    world.roster.observeDeep(rebuild)
-
-    // Current scene entities
-    let sceneEntitiesMap: Y.Map<unknown> | null = null
-    if (currentSceneId) {
-      const sceneMap = world.scenes.get(currentSceneId)
-      if (sceneMap instanceof Y.Map) {
-        sceneEntitiesMap = sceneMap.get('entities') as Y.Map<unknown> | null
-        if (sceneEntitiesMap instanceof Y.Map) {
-          sceneEntitiesMap.observe(rebuild)
-        }
-      }
-    }
-
-    return () => {
-      world.roster.unobserveDeep(rebuild)
-      if (sceneEntitiesMap instanceof Y.Map) {
-        sceneEntitiesMap.unobserve(rebuild)
-      }
-    }
-  }, [world, currentSceneId, rebuild])
+    world.entities.observeDeep(rebuild)
+    return () => world.entities.unobserveDeep(rebuild)
+  }, [world, rebuild])
 
   // --- CRUD ---
 
-  /** Add entity to roster (nested Y.Map for field-level CRDT) */
-  const addRosterEntity = useCallback(
+  /** Add entity to the global entities store (nested Y.Map for field-level CRDT) */
+  const addEntity = useCallback(
     (entity: Entity) => {
       yDoc.transact(() => {
         const yMap = new Y.Map<unknown>()
-        world.roster.set(entity.id, yMap)
+        world.entities.set(entity.id, yMap)
         setYMapFields(yMap, entity)
       })
     },
     [world, yDoc],
   )
 
-  /** Add NPC to current scene (plain object) */
-  const addSceneEntity = useCallback(
-    (entity: Entity, sceneId?: string) => {
-      const targetSceneId = sceneId ?? currentSceneId
-      if (!targetSceneId) return
-      const sceneMap = world.scenes.get(targetSceneId)
-      if (!(sceneMap instanceof Y.Map)) return
-      const sceneEntities = sceneMap.get('entities') as Y.Map<Entity> | undefined
-      if (sceneEntities instanceof Y.Map) {
-        sceneEntities.set(entity.id, entity)
-      }
-    },
-    [world, currentSceneId],
-  )
-
-  /** Update entity (auto-detects source) */
+  /** Update entity fields */
   const updateEntity = useCallback(
     (id: string, updates: Partial<Entity>) => {
-      // Check roster first (nested Y.Map)
-      const rosterYMap = world.roster.get(id)
-      if (rosterYMap instanceof Y.Map) {
-        yDoc.transact(() => {
-          for (const [key, value] of Object.entries(updates)) {
-            if (key === 'permissions') {
-              updatePermissions(rosterYMap, value as EntityPermissions)
-            } else if (key === 'ruleData') {
-              updateRuleData(rosterYMap, value)
-            } else {
-              rosterYMap.set(key, value)
-            }
-          }
-        })
-        return
-      }
-
-      // Check current scene
-      if (currentSceneId) {
-        const sceneMap = world.scenes.get(currentSceneId)
-        if (sceneMap instanceof Y.Map) {
-          const sceneEntities = sceneMap.get('entities') as Y.Map<Entity> | undefined
-          if (sceneEntities instanceof Y.Map) {
-            const existing = sceneEntities.get(id)
-            if (existing) {
-              sceneEntities.set(id, { ...existing, ...updates })
-              return
-            }
+      const entityYMap = world.entities.get(id)
+      if (!(entityYMap instanceof Y.Map)) return
+      yDoc.transact(() => {
+        for (const [key, value] of Object.entries(updates)) {
+          if (key === 'permissions') {
+            updatePermissions(entityYMap, value as EntityPermissions)
+          } else if (key === 'ruleData') {
+            updateRuleData(entityYMap, value)
+          } else {
+            entityYMap.set(key, value)
           }
         }
-      }
+      })
     },
-    [world, currentSceneId, yDoc],
+    [world, yDoc],
   )
 
-  /** Delete entity from wherever it lives */
+  /** Delete entity from the global store */
   const deleteEntity = useCallback(
     (id: string) => {
-      if (world.roster.has(id)) {
-        world.roster.delete(id)
-        return
-      }
-      if (currentSceneId) {
-        const sceneMap = world.scenes.get(currentSceneId)
-        if (sceneMap instanceof Y.Map) {
-          const sceneEntities = sceneMap.get('entities') as Y.Map<Entity> | undefined
-          if (sceneEntities instanceof Y.Map && sceneEntities.has(id)) {
-            sceneEntities.delete(id)
-          }
-        }
-      }
+      world.entities.delete(id)
     },
-    [world, currentSceneId],
+    [world],
   )
 
   /** Get entity by ID */
@@ -277,33 +194,11 @@ export function useEntities(world: WorldMaps, currentSceneId: string | null, yDo
     [entities],
   )
 
-  /** Promote entity from scene to roster (cross-scene persistent) */
-  const promoteToRoster = useCallback(
-    (id: string) => {
-      if (!currentSceneId) return
-      const sceneMap = world.scenes.get(currentSceneId)
-      if (!(sceneMap instanceof Y.Map)) return
-      const sceneEntities = sceneMap.get('entities') as Y.Map<Entity> | undefined
-      if (!(sceneEntities instanceof Y.Map)) return
-      const entity = sceneEntities.get(id)
-      if (!entity) return
-      yDoc.transact(() => {
-        const yMap = new Y.Map<unknown>()
-        world.roster.set(id, yMap)
-        setYMapFields(yMap, entity)
-        sceneEntities.delete(id)
-      })
-    },
-    [world, currentSceneId, yDoc],
-  )
-
   return {
-    entities: entities as Entity[],
-    addRosterEntity,
-    addSceneEntity,
+    entities,
+    addEntity,
     updateEntity,
     deleteEntity,
     getEntity,
-    promoteToRoster,
   }
 }

--- a/src/gm/GmToolbar.tsx
+++ b/src/gm/GmToolbar.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react'
 import type { Scene } from '../yjs/useScenes'
-import type { RoomState } from '../yjs/useRoom'
 import { SceneLibrary } from './SceneLibrary'
 import { isVideoUrl } from '../shared/assetUpload'
 
 interface GmToolbarProps {
   scenes: Scene[]
-  room: RoomState
+  activeSceneId: string | null
+  isCombat: boolean
   onSelectScene: (sceneId: string) => void
-  onEnterCombat: () => void
-  onExitCombat: () => void
+  onToggleCombat: () => void
   onAddScene: (scene: Scene) => void
   onUpdateScene: (id: string, updates: Partial<Scene>) => void
   onDeleteScene: (id: string) => void
@@ -17,18 +16,16 @@ interface GmToolbarProps {
 
 export function GmToolbar({
   scenes,
-  room,
+  activeSceneId,
+  isCombat,
   onSelectScene,
-  onEnterCombat,
-  onExitCombat,
+  onToggleCombat,
   onAddScene,
   onUpdateScene,
   onDeleteScene,
 }: GmToolbarProps) {
   const [showScenePicker, setShowScenePicker] = useState(false)
   const [showLibrary, setShowLibrary] = useState(false)
-
-  const isCombat = room.mode === 'combat'
 
   return (
     <>
@@ -119,8 +116,7 @@ export function GmToolbar({
                     gap: 8,
                     width: '100%',
                     padding: '8px 12px',
-                    background:
-                      scene.id === room.activeSceneId ? 'rgba(59,130,246,0.1)' : 'transparent',
+                    background: scene.id === activeSceneId ? 'rgba(59,130,246,0.1)' : 'transparent',
                     border: 'none',
                     borderRadius: 6,
                     cursor: 'pointer',
@@ -156,7 +152,7 @@ export function GmToolbar({
                   )}
                   <span
                     style={{
-                      fontWeight: scene.id === room.activeSceneId ? 600 : 400,
+                      fontWeight: scene.id === activeSceneId ? 600 : 400,
                       color: '#333',
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',
@@ -194,7 +190,7 @@ export function GmToolbar({
 
         {/* Combat toggle */}
         <button
-          onClick={isCombat ? onExitCombat : onEnterCombat}
+          onClick={onToggleCombat}
           style={{
             padding: '8px 14px',
             background: isCombat ? 'rgba(239,68,68,0.9)' : 'rgba(255,255,255,0.92)',

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -164,7 +164,9 @@ export function PortraitBar({
   )
 
   // Filter to entities visible to this seat
-  const visibleEntities = entities.filter((e) => (mySeatId ? canSee(e, mySeatId, role) : isGM))
+  const visibleEntities = entities.filter((e) =>
+    mySeatId ? canSee(e.permissions, mySeatId, role) : isGM,
+  )
 
   if (visibleEntities.length === 0) return null
 
@@ -186,7 +188,7 @@ export function PortraitBar({
   const getContextMenuItems = (entity: Entity): ContextMenuItem[] => {
     const items: ContextMenuItem[] = []
 
-    if (mySeatId && canEdit(entity, mySeatId, role)) {
+    if (mySeatId && canEdit(entity.permissions, mySeatId, role)) {
       items.push({
         label: 'Set as active',
         onClick: () => onSetActiveCharacter(entity.id),
@@ -217,7 +219,7 @@ export function PortraitBar({
   }
 
   const renderPortrait = (entity: Entity) => {
-    const isOwner = mySeatId ? canEdit(entity, mySeatId, role) : false
+    const isOwner = mySeatId ? canEdit(entity.permissions, mySeatId, role) : false
     const isInspected = inspectedCharacterId === entity.id
     const isActive = activeCharacterId === entity.id
 
@@ -434,7 +436,8 @@ export function PortraitBar({
   }
 
   // Determine if the inspected entity is editable
-  const isEditable = popoverEntity && isLocked && mySeatId && canEdit(popoverEntity, mySeatId, role)
+  const isEditable =
+    popoverEntity && isLocked && mySeatId && canEdit(popoverEntity.permissions, mySeatId, role)
   const popoverWidth = isLocked ? (isEditable ? 320 : 260) : 220
 
   // Calculate popover position
@@ -597,7 +600,7 @@ export function PortraitBar({
               <CharacterHoverPreview
                 character={popoverEntity}
                 isOnline={false}
-                editable={mySeatId ? canEdit(popoverEntity, mySeatId, role) : false}
+                editable={mySeatId ? canEdit(popoverEntity.permissions, mySeatId, role) : false}
                 onUpdateCharacter={onUpdateEntity}
               />
             )}

--- a/src/shared/__tests__/permissions.test.ts
+++ b/src/shared/__tests__/permissions.test.ts
@@ -6,31 +6,25 @@ import {
   defaultNPCPermissions,
   hiddenNPCPermissions,
 } from '../permissions'
-import { makeEntity } from '../../__test-utils__/fixtures'
+import type { EntityPermissions } from '../entityTypes'
 
-const ownerEntity = makeEntity({
-  permissions: { default: 'none', seats: { 'seat-1': 'owner' } },
-})
-const observerEntity = makeEntity({
-  permissions: { default: 'observer', seats: {} },
-})
-const hiddenEntity = makeEntity({
-  permissions: { default: 'none', seats: {} },
-})
+const ownerPerms: EntityPermissions = { default: 'none', seats: { 'seat-1': 'owner' } }
+const observerPerms: EntityPermissions = { default: 'observer', seats: {} }
+const hiddenPerms: EntityPermissions = { default: 'none', seats: {} }
 
 // ── getPermission ───────────────────────────────────────────────
 
 describe('getPermission', () => {
   it('returns seat-specific permission when present', () => {
-    expect(getPermission(ownerEntity, 'seat-1')).toBe('owner')
+    expect(getPermission(ownerPerms, 'seat-1')).toBe('owner')
   })
 
   it('falls back to default when seat not in record', () => {
-    expect(getPermission(ownerEntity, 'seat-unknown')).toBe('none')
+    expect(getPermission(ownerPerms, 'seat-unknown')).toBe('none')
   })
 
   it('returns default for entity with empty seats', () => {
-    expect(getPermission(observerEntity, 'seat-1')).toBe('observer')
+    expect(getPermission(observerPerms, 'seat-1')).toBe('observer')
   })
 })
 
@@ -38,19 +32,19 @@ describe('getPermission', () => {
 
 describe('canSee', () => {
   it('GM can always see', () => {
-    expect(canSee(hiddenEntity, 'seat-1', 'GM')).toBe(true)
+    expect(canSee(hiddenPerms, 'seat-1', 'GM')).toBe(true)
   })
 
   it('PL with none permission cannot see', () => {
-    expect(canSee(hiddenEntity, 'seat-1', 'PL')).toBe(false)
+    expect(canSee(hiddenPerms, 'seat-1', 'PL')).toBe(false)
   })
 
   it('PL with observer permission can see', () => {
-    expect(canSee(observerEntity, 'seat-1', 'PL')).toBe(true)
+    expect(canSee(observerPerms, 'seat-1', 'PL')).toBe(true)
   })
 
   it('PL with owner permission can see', () => {
-    expect(canSee(ownerEntity, 'seat-1', 'PL')).toBe(true)
+    expect(canSee(ownerPerms, 'seat-1', 'PL')).toBe(true)
   })
 })
 
@@ -58,19 +52,19 @@ describe('canSee', () => {
 
 describe('canEdit', () => {
   it('GM can always edit', () => {
-    expect(canEdit(hiddenEntity, 'seat-1', 'GM')).toBe(true)
+    expect(canEdit(hiddenPerms, 'seat-1', 'GM')).toBe(true)
   })
 
   it('PL with owner permission can edit', () => {
-    expect(canEdit(ownerEntity, 'seat-1', 'PL')).toBe(true)
+    expect(canEdit(ownerPerms, 'seat-1', 'PL')).toBe(true)
   })
 
   it('PL with observer permission cannot edit', () => {
-    expect(canEdit(observerEntity, 'seat-1', 'PL')).toBe(false)
+    expect(canEdit(observerPerms, 'seat-1', 'PL')).toBe(false)
   })
 
   it('PL with none permission cannot edit', () => {
-    expect(canEdit(hiddenEntity, 'seat-1', 'PL')).toBe(false)
+    expect(canEdit(hiddenPerms, 'seat-1', 'PL')).toBe(false)
   })
 })
 

--- a/src/shared/entityTypes.ts
+++ b/src/shared/entityTypes.ts
@@ -17,6 +17,7 @@ export interface Entity {
   notes: string
   ruleData: unknown
   permissions: EntityPermissions
+  persistent: boolean
 }
 
 export interface MapToken {
@@ -25,7 +26,7 @@ export interface MapToken {
   x: number
   y: number
   size: number
-  gmOnly: boolean
+  permissions: EntityPermissions
   label?: string
   imageUrl?: string
   color?: string

--- a/src/shared/permissions.ts
+++ b/src/shared/permissions.ts
@@ -1,18 +1,33 @@
 // src/shared/permissions.ts
-import type { Entity, PermissionLevel } from './entityTypes'
+import type { Entity, EntityPermissions, MapToken, PermissionLevel } from './entityTypes'
 
-export function getPermission(entity: Entity, seatId: string): PermissionLevel {
-  return entity.permissions.seats[seatId] ?? entity.permissions.default
+export function getPermission(permissions: EntityPermissions, seatId: string): PermissionLevel {
+  return permissions.seats[seatId] ?? permissions.default
 }
 
-export function canSee(entity: Entity, seatId: string, role: 'GM' | 'PL'): boolean {
+export function canSee(permissions: EntityPermissions, seatId: string, role: 'GM' | 'PL'): boolean {
   if (role === 'GM') return true
-  return getPermission(entity, seatId) !== 'none'
+  return getPermission(permissions, seatId) !== 'none'
 }
 
-export function canEdit(entity: Entity, seatId: string, role: 'GM' | 'PL'): boolean {
+export function canEdit(
+  permissions: EntityPermissions,
+  seatId: string,
+  role: 'GM' | 'PL',
+): boolean {
   if (role === 'GM') return true
-  return getPermission(entity, seatId) === 'owner'
+  return getPermission(permissions, seatId) === 'owner'
+}
+
+export function getEffectivePermissions(
+  token: MapToken,
+  getEntity: (id: string) => Entity | null,
+): EntityPermissions {
+  if (token.entityId) {
+    const entity = getEntity(token.entityId)
+    if (entity) return entity.permissions
+  }
+  return token.permissions
 }
 
 export function defaultPCPermissions(ownerSeatId: string): Entity['permissions'] {

--- a/src/yjs/__tests__/useRoom.sync.test.ts
+++ b/src/yjs/__tests__/useRoom.sync.test.ts
@@ -10,28 +10,11 @@ describe('useRoom — multi-client sync', () => {
     return { doc1, doc2, world1, world2, hook1, hook2 }
   }
 
-  it('Client A switches to combat mode → Client B syncs', () => {
-    const { hook1, hook2 } = setup()
-
-    act(() => hook1.result.current.setMode('combat'))
-
-    expect(hook2.result.current.room.mode).toBe('combat')
-  })
-
   it('Client A sets activeSceneId → Client B sees it', () => {
     const { hook1, hook2 } = setup()
 
     act(() => hook1.result.current.setActiveScene('scene-1'))
 
     expect(hook2.result.current.room.activeSceneId).toBe('scene-1')
-  })
-
-  it('Client A enterCombat → Client B sees mode + combatSceneId', () => {
-    const { hook1, hook2 } = setup()
-
-    act(() => hook1.result.current.enterCombat('scene-2'))
-
-    expect(hook2.result.current.room.mode).toBe('combat')
-    expect(hook2.result.current.room.combatSceneId).toBe('scene-2')
   })
 })

--- a/src/yjs/__tests__/useRoom.test.ts
+++ b/src/yjs/__tests__/useRoom.test.ts
@@ -12,75 +12,14 @@ describe('useRoom', () => {
 
   // ── initial state ───────────────────────────────────────────
 
-  it('defaults to scene mode with null scene ids', () => {
+  it('defaults to null activeSceneId', () => {
     const { hook } = setup()
     expect(hook.result.current.room).toEqual({
-      mode: 'scene',
       activeSceneId: null,
-      combatSceneId: null,
     })
   })
 
-  // ── setMode ─────────────────────────────────────────────────
-
-  it('switches to combat mode', () => {
-    const { hook } = setup()
-
-    act(() => hook.result.current.setMode('combat'))
-
-    expect(hook.result.current.room.mode).toBe('combat')
-  })
-
-  it('sets combatSceneId from activeSceneId when entering combat without one', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.setActiveScene('scene-1'))
-
-    act(() => hook.result.current.setMode('combat'))
-
-    expect(hook.result.current.room.combatSceneId).toBe('scene-1')
-  })
-
-  // ── enterCombat ─────────────────────────────────────────────
-
-  it('enters combat with explicit sceneId', () => {
-    const { hook } = setup()
-
-    act(() => hook.result.current.enterCombat('scene-2'))
-
-    expect(hook.result.current.room.mode).toBe('combat')
-    expect(hook.result.current.room.combatSceneId).toBe('scene-2')
-  })
-
-  it('enters combat falling back to activeSceneId when no arg and no combatSceneId', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.setActiveScene('scene-1'))
-
-    act(() => hook.result.current.enterCombat())
-
-    expect(hook.result.current.room.combatSceneId).toBe('scene-1')
-  })
-
-  it('enters combat keeping existing combatSceneId when no arg', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.setCombatScene('scene-3'))
-
-    act(() => hook.result.current.enterCombat())
-
-    expect(hook.result.current.room.combatSceneId).toBe('scene-3')
-  })
-
-  // ── exitCombat ──────────────────────────────────────────────
-
-  it('exits combat back to scene mode', () => {
-    const { hook } = setup()
-    act(() => hook.result.current.enterCombat('scene-1'))
-
-    act(() => hook.result.current.exitCombat())
-
-    expect(hook.result.current.room.mode).toBe('scene')
-  })
-
-  // ── setActiveScene / setCombatScene ─────────────────────────
+  // ── setActiveScene ─────────────────────────────────────────
 
   it('sets active scene', () => {
     const { hook } = setup()
@@ -90,25 +29,15 @@ describe('useRoom', () => {
     expect(hook.result.current.room.activeSceneId).toBe('scene-5')
   })
 
-  it('sets combat scene', () => {
-    const { hook } = setup()
-
-    act(() => hook.result.current.setCombatScene('scene-7'))
-
-    expect(hook.result.current.room.combatSceneId).toBe('scene-7')
-  })
-
   // ── external Yjs change syncs to hook ───────────────────────
 
   it('syncs when yRoom is mutated externally', () => {
     const { hook, yRoom } = setup()
 
     act(() => {
-      yRoom.set('mode', 'combat')
       yRoom.set('activeSceneId', 'ext-scene')
     })
 
-    expect(hook.result.current.room.mode).toBe('combat')
     expect(hook.result.current.room.activeSceneId).toBe('ext-scene')
   })
 })

--- a/src/yjs/__tests__/useScenes.sync.test.ts
+++ b/src/yjs/__tests__/useScenes.sync.test.ts
@@ -15,6 +15,8 @@ const baseScene: Scene = {
   gridOffsetX: 0,
   gridOffsetY: 0,
   sortOrder: 0,
+  combatActive: false,
+  battleMapUrl: '',
 }
 
 describe('useScenes — multi-client sync', () => {
@@ -25,7 +27,7 @@ describe('useScenes — multi-client sync', () => {
     return { doc1, doc2, world1, world2, hook1, hook2 }
   }
 
-  it('Client A adds scene → Client B sees it with entities/tokens sub-maps', () => {
+  it('Client A adds scene → Client B sees it with entityIds/tokens sub-maps', () => {
     const { hook1, hook2, world2 } = setup()
 
     act(() => hook1.result.current.addScene(baseScene))
@@ -36,8 +38,8 @@ describe('useScenes — multi-client sync', () => {
     // Verify nested containers synced
     const sceneMap = world2.scenes.get('scene-1')
     expect(sceneMap).toBeInstanceOf(Y.Map)
-    expect(sceneMap!.get('entities')).toBeInstanceOf(Y.Map)
-    expect(sceneMap!.get('tokens')).toBeInstanceOf(Y.Map)
+    expect((sceneMap as Y.Map<unknown>).get('entityIds')).toBeInstanceOf(Y.Map)
+    expect((sceneMap as Y.Map<unknown>).get('tokens')).toBeInstanceOf(Y.Map)
   })
 
   it('Client A updates gridSize → Client B syncs', () => {

--- a/src/yjs/__tests__/useScenes.test.ts
+++ b/src/yjs/__tests__/useScenes.test.ts
@@ -16,6 +16,8 @@ function makeScene(overrides?: Partial<Scene>): Scene {
     gridOffsetX: 0,
     gridOffsetY: 0,
     sortOrder: 0,
+    combatActive: false,
+    battleMapUrl: '',
     ...overrides,
   }
 }
@@ -46,14 +48,14 @@ describe('useScenes', () => {
     expect(hook.result.current.scenes[0].name).toBe('Tavern')
   })
 
-  it('creates entities and tokens sub-maps on add', () => {
+  it('creates entityIds and tokens sub-maps on add', () => {
     const { hook, scenes } = setup()
 
     act(() => hook.result.current.addScene(makeScene({ id: 'sc-1' })))
 
     const sceneMap = scenes.get('sc-1')
     expect(sceneMap).toBeInstanceOf(Y.Map)
-    expect(sceneMap?.get('entities')).toBeInstanceOf(Y.Map)
+    expect(sceneMap?.get('entityIds')).toBeInstanceOf(Y.Map)
     expect(sceneMap?.get('tokens')).toBeInstanceOf(Y.Map)
   })
 

--- a/src/yjs/useRoom.ts
+++ b/src/yjs/useRoom.ts
@@ -2,16 +2,12 @@ import { useEffect, useState } from 'react'
 import * as Y from 'yjs'
 
 export interface RoomState {
-  mode: 'scene' | 'combat'
   activeSceneId: string | null
-  combatSceneId: string | null
 }
 
 function readRoom(yRoom: Y.Map<unknown>): RoomState {
   return {
-    mode: (yRoom.get('mode') as RoomState['mode']) ?? 'scene',
     activeSceneId: (yRoom.get('activeSceneId') as string) ?? null,
-    combatSceneId: (yRoom.get('combatSceneId') as string) ?? null,
   }
 }
 
@@ -25,44 +21,12 @@ export function useRoom(yRoom: Y.Map<unknown>) {
     return () => yRoom.unobserve(observer)
   }, [yRoom])
 
-  const setMode = (mode: 'scene' | 'combat') => {
-    yRoom.doc?.transact(() => {
-      yRoom.set('mode', mode)
-      if (mode === 'combat' && !yRoom.get('combatSceneId')) {
-        yRoom.set('combatSceneId', yRoom.get('activeSceneId'))
-      }
-    })
-  }
-
   const setActiveScene = (sceneId: string) => {
     yRoom.set('activeSceneId', sceneId)
   }
 
-  const setCombatScene = (sceneId: string) => {
-    yRoom.set('combatSceneId', sceneId)
-  }
-
-  const enterCombat = (sceneId?: string) => {
-    yRoom.doc?.transact(() => {
-      yRoom.set('mode', 'combat')
-      if (sceneId) {
-        yRoom.set('combatSceneId', sceneId)
-      } else if (!yRoom.get('combatSceneId')) {
-        yRoom.set('combatSceneId', yRoom.get('activeSceneId'))
-      }
-    })
-  }
-
-  const exitCombat = () => {
-    yRoom.set('mode', 'scene')
-  }
-
   return {
     room,
-    setMode,
     setActiveScene,
-    setCombatScene,
-    enterCombat,
-    exitCombat,
   }
 }

--- a/src/yjs/useScenes.ts
+++ b/src/yjs/useScenes.ts
@@ -13,6 +13,8 @@ export interface Scene {
   gridOffsetX: number
   gridOffsetY: number
   sortOrder: number
+  combatActive: boolean
+  battleMapUrl: string
 }
 
 function readScenes(yScenes: Y.Map<Y.Map<unknown>>): Scene[] {
@@ -31,6 +33,8 @@ function readScenes(yScenes: Y.Map<Y.Map<unknown>>): Scene[] {
       gridOffsetX: (sceneMap.get('gridOffsetX') as number) ?? 0,
       gridOffsetY: (sceneMap.get('gridOffsetY') as number) ?? 0,
       sortOrder: (sceneMap.get('sortOrder') as number) ?? 0,
+      combatActive: (sceneMap.get('combatActive') as boolean) ?? false,
+      battleMapUrl: (sceneMap.get('battleMapUrl') as string) ?? '',
     })
   })
   scenes.sort((a, b) => a.sortOrder - b.sortOrder)
@@ -47,7 +51,7 @@ export function useScenes(yScenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc) {
     return () => yScenes.unobserveDeep(observer)
   }, [yScenes])
 
-  const addScene = (scene: Scene) => {
+  const addScene = (scene: Scene, persistentEntityIds?: string[]) => {
     yDoc.transact(() => {
       const sceneMap = new Y.Map<unknown>()
       yScenes.set(scene.id, sceneMap)
@@ -61,8 +65,17 @@ export function useScenes(yScenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc) {
       sceneMap.set('gridOffsetX', scene.gridOffsetX)
       sceneMap.set('gridOffsetY', scene.gridOffsetY)
       sceneMap.set('sortOrder', scene.sortOrder)
-      // Nested containers for entities and tokens
-      sceneMap.set('entities', new Y.Map())
+      sceneMap.set('combatActive', false)
+      sceneMap.set('battleMapUrl', '')
+      // entityIds: references to entities in this scene
+      const entityIdsMap = new Y.Map<boolean>()
+      sceneMap.set('entityIds', entityIdsMap)
+      if (persistentEntityIds) {
+        for (const eid of persistentEntityIds) {
+          entityIdsMap.set(eid, true)
+        }
+      }
+      // tokens: combat tokens for this scene
       sceneMap.set('tokens', new Y.Map())
     })
   }
@@ -98,8 +111,54 @@ export function useScenes(yScenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc) {
       gridOffsetX: (sceneMap.get('gridOffsetX') as number) ?? 0,
       gridOffsetY: (sceneMap.get('gridOffsetY') as number) ?? 0,
       sortOrder: (sceneMap.get('sortOrder') as number) ?? 0,
+      combatActive: (sceneMap.get('combatActive') as boolean) ?? false,
+      battleMapUrl: (sceneMap.get('battleMapUrl') as string) ?? '',
     }
   }
 
-  return { scenes, addScene, updateScene, deleteScene, getScene }
+  const addEntityToScene = (sceneId: string, entityId: string) => {
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    const entityIds = sceneMap.get('entityIds')
+    if (entityIds instanceof Y.Map) {
+      entityIds.set(entityId, true)
+    }
+  }
+
+  const removeEntityFromScene = (sceneId: string, entityId: string) => {
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    const entityIds = sceneMap.get('entityIds')
+    if (entityIds instanceof Y.Map) {
+      entityIds.delete(entityId)
+    }
+  }
+
+  const getSceneEntityIds = (sceneId: string): string[] => {
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return []
+    const entityIds = sceneMap.get('entityIds')
+    if (!(entityIds instanceof Y.Map)) return []
+    const ids: string[] = []
+    entityIds.forEach((_val, key) => ids.push(key))
+    return ids
+  }
+
+  const setCombatActive = (sceneId: string, active: boolean) => {
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    sceneMap.set('combatActive', active)
+  }
+
+  return {
+    scenes,
+    addScene,
+    updateScene,
+    deleteScene,
+    getScene,
+    addEntityToScene,
+    removeEntityFromScene,
+    getSceneEntityIds,
+    setCombatActive,
+  }
 }

--- a/src/yjs/useWorld.ts
+++ b/src/yjs/useWorld.ts
@@ -3,15 +3,15 @@ import { useMemo } from 'react'
 import * as Y from 'yjs'
 
 export interface WorldMaps {
-  /** Y.Map of sceneId → Y.Map (each scene contains config keys, 'entities' Y.Map, 'tokens' Y.Map) */
+  /** Y.Map of sceneId → Y.Map (each scene contains config keys, 'entityIds' Y.Map, 'tokens' Y.Map) */
   scenes: Y.Map<Y.Map<unknown>>
-  /** Y.Map of entityId → Y.Map (cross-scene persistent characters, field-level CRDT) */
-  roster: Y.Map<Y.Map<unknown>>
+  /** Y.Map of entityId → Y.Map (all entities, field-level CRDT) */
+  entities: Y.Map<Y.Map<unknown>>
   /** Y.Map of blueprintId → plain Blueprint object */
   blueprints: Y.Map<unknown>
   /** Y.Map of seatId → plain Seat object */
   seats: Y.Map<unknown>
-  /** Y.Map of room-level state (mode, activeSceneId, etc.) */
+  /** Y.Map of room-level state (activeSceneId) */
   room: Y.Map<unknown>
 }
 
@@ -23,7 +23,7 @@ export interface WorldMaps {
 export function createWorldMaps(yDoc: Y.Doc): WorldMaps {
   return {
     scenes: yDoc.getMap('scenes') as Y.Map<Y.Map<unknown>>,
-    roster: yDoc.getMap('roster') as Y.Map<Y.Map<unknown>>,
+    entities: yDoc.getMap('entities') as Y.Map<Y.Map<unknown>>,
     blueprints: yDoc.getMap('blueprints'),
     seats: yDoc.getMap('seats'),
     room: yDoc.getMap('room'),


### PR DESCRIPTION
## 概要
Phase 1 核心数据层重构，统一实体系统架构。

- Entity 新增 `persistent: boolean` 字段，控制跨场景生命周期
- MapToken 的 `gmOnly: boolean` 替换为统一 `permissions: EntityPermissions` 权限模型
- `roster` 重命名为 `entities`，合并为单一全局实体源（移除 `addSceneEntity`/`promoteToRoster` 双源设计）
- useRoom 简化：移除 `mode`/`combatSceneId`，仅保留 `activeSceneId`；战斗状态（`combatActive`/`battleMapUrl`）下沉到 Scene 级别
- Scene 的 `entities` 子 Y.Map 替换为 `entityIds` Y.Map<boolean> 引用表
- 新增 `getEffectivePermissions()` 统一解析 token 权限（entity-linked → entity permissions，standalone → token permissions）

## 变更范围
- 23 个文件修改，净减 242 行
- 核心类型、hooks、消费者组件、测试工具、测试用例全部同步更新

## 测试计划
- [x] TypeScript 编译零错误 (`npx tsc --noEmit`)
- [x] 164 个测试全部通过 (`npx vitest run`)
- [x] ESLint + Prettier 通过（pre-commit hook）