### PR TITLE
feat: wire entity-scene linking and PortraitBar scene filtering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,12 +46,19 @@ function RoomSession({ roomId }: { roomId: string }) {
     updateSeat,
   } = useIdentity(world.seats, awareness)
   const { room, setActiveScene } = useRoom(world.room)
-  const { scenes, addScene, updateScene, deleteScene, getScene, setCombatActive } = useScenes(
-    world.scenes,
-    yDoc,
-  )
+  const {
+    scenes,
+    addScene,
+    updateScene,
+    deleteScene,
+    getScene,
+    addEntityToScene,
+    removeEntityFromScene,
+    getSceneEntityIds,
+    setCombatActive,
+  } = useScenes(world.scenes, yDoc)
 
-  const { entities, addEntity, updateEntity, deleteEntity, getEntity } = useEntities(world, yDoc)
+  const { entities, addEntity, updateEntity, getEntity } = useEntities(world, yDoc)
 
   const activeScene = getScene(room.activeSceneId)
   const isCombat = activeScene?.combatActive ?? false
@@ -146,9 +153,12 @@ function RoomSession({ roomId }: { roomId: string }) {
   // Deduplicate by key — later entries (token entity) override earlier (active entity)
   const seatProperties = [...new Map(allProps.map((p) => [p.key, p])).values()]
 
-  // Handle deleting an entity
-  const handleDeleteEntity = (entityId: string) => {
-    deleteEntity(entityId)
+  // Derive current scene's entity IDs for PortraitBar filtering
+  const sceneEntityIds = room.activeSceneId ? getSceneEntityIds(room.activeSceneId) : []
+
+  // Handle removing an entity from the current scene (without deleting it)
+  const handleRemoveFromScene = (entityId: string) => {
+    if (room.activeSceneId) removeEntityFromScene(room.activeSceneId, entityId)
     if (inspectedCharacterId === entityId) setInspectedCharacterId(null)
   }
 
@@ -194,6 +204,7 @@ function RoomSession({ roomId }: { roomId: string }) {
       persistent: false,
     }
     addEntity(newEntity)
+    if (room.activeSceneId) addEntityToScene(room.activeSceneId, newEntity.id)
     setInspectedCharacterId(newEntity.id)
     setBgContextMenu(null)
   }
@@ -222,6 +233,7 @@ function RoomSession({ roomId }: { roomId: string }) {
       {/* Top-center: Portrait bar */}
       <PortraitBar
         entities={entities}
+        sceneEntityIds={sceneEntityIds}
         mySeatId={mySeatId}
         role={mySeat.role}
         isGM={isGM}
@@ -230,7 +242,7 @@ function RoomSession({ roomId }: { roomId: string }) {
         activeCharacterId={mySeat.activeCharacterId ?? null}
         onInspectCharacter={setInspectedCharacterId}
         onSetActiveCharacter={handleSetActiveCharacter}
-        onDeleteEntity={handleDeleteEntity}
+        onRemoveFromScene={handleRemoveFromScene}
         onUpdateEntity={updateEntity}
       />
 
@@ -267,6 +279,9 @@ function RoomSession({ roomId }: { roomId: string }) {
           blueprints={world.blueprints}
           entities={entities}
           onAddEntity={addEntity}
+          onAddEntityToScene={(entityId) => {
+            if (room.activeSceneId) addEntityToScene(room.activeSceneId, entityId)
+          }}
           isCombat={isCombat}
           selectedToken={getToken(selectedTokenId)}
           onAddToken={addToken}

--- a/src/dock/BottomDock.tsx
+++ b/src/dock/BottomDock.tsx
@@ -29,6 +29,7 @@ interface BottomDockProps {
 
   entities: Entity[]
   onAddEntity: (entity: Entity) => void
+  onAddEntityToScene: (entityId: string) => void
   isCombat: boolean
 
   selectedToken: MapToken | null
@@ -52,6 +53,7 @@ export function BottomDock({
   onShowcaseHandout,
   entities,
   onAddEntity,
+  onAddEntityToScene,
   isCombat,
   selectedToken,
   onAddToken,
@@ -135,6 +137,7 @@ export function BottomDock({
       blueprintId: bp.id,
     }
     onAddEntity(entity)
+    onAddEntityToScene(entity.id)
     return entity
   }
 

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -13,6 +13,7 @@ type PortraitTabId = 'characters' | 'initiative'
 
 interface PortraitBarProps {
   entities: Entity[]
+  sceneEntityIds: string[]
   mySeatId: string | null
   role: 'GM' | 'PL'
   isGM: boolean
@@ -21,7 +22,7 @@ interface PortraitBarProps {
   activeCharacterId: string | null
   onInspectCharacter: (charId: string | null) => void
   onSetActiveCharacter: (charId: string) => void
-  onDeleteEntity: (entityId: string) => void
+  onRemoveFromScene: (entityId: string) => void
   onUpdateEntity: (id: string, updates: Partial<Entity>) => void
 }
 
@@ -78,6 +79,7 @@ function ResourceRingBg({ index, size }: { index: number; size: number }) {
 
 export function PortraitBar({
   entities,
+  sceneEntityIds,
   mySeatId,
   role,
   isGM,
@@ -86,7 +88,7 @@ export function PortraitBar({
   activeCharacterId,
   onInspectCharacter,
   onSetActiveCharacter,
-  onDeleteEntity,
+  onRemoveFromScene,
   onUpdateEntity,
 }: PortraitBarProps) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; entityId: string } | null>(
@@ -163,9 +165,12 @@ export function PortraitBar({
     [inspectedCharacterId, onInspectCharacter],
   )
 
-  // Filter to entities visible to this seat
-  const visibleEntities = entities.filter((e) =>
-    mySeatId ? canSee(e.permissions, mySeatId, role) : isGM,
+  // Filter to entities in the current scene (or persistent) and visible to this seat
+  const sceneIdSet = new Set(sceneEntityIds)
+  const visibleEntities = entities.filter(
+    (e) =>
+      (e.persistent || sceneIdSet.has(e.id)) &&
+      (mySeatId ? canSee(e.permissions, mySeatId, role) : isGM),
   )
 
   if (visibleEntities.length === 0) return null
@@ -207,10 +212,10 @@ export function PortraitBar({
       },
     })
 
-    if (isGM && !Object.values(entity.permissions.seats).includes('owner')) {
+    if (isGM && !entity.persistent) {
       items.push({
         label: 'Remove from scene',
-        onClick: () => onDeleteEntity(entity.id),
+        onClick: () => onRemoveFromScene(entity.id),
         color: '#f87171',
       })
     }


### PR DESCRIPTION
## 概要
Phase 2A：将实体创建流程与场景 entityIds 关联，PortraitBar 按场景过滤。

- `App.tsx handleAddNpc`：创建实体后调用 `addEntityToScene(activeSceneId, entityId)`
- `BottomDock createEntityFromBlueprint`：创建实体后调用 `onAddEntityToScene(entityId)`
- `PortraitBar`：按 `scene.entityIds` 过滤显示实体（persistent 实体始终显示）
- `PortraitBar`："Remove from scene" 改为调用 `removeEntityFromScene` 而非 `deleteEntity`
- 移除 PortraitBar 的 `onDeleteEntity` prop（不再需要）

## 测试计划
- [x] TypeScript 编译零错误
- [x] 164 个测试全部通过
- [x] ESLint + Prettier 通过