### PR TITLE
feat: entity lifecycle GC and persistent auto-join

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useYjsConnection } from './yjs/useYjsConnection'
 import { AdminPanel } from './admin/AdminPanel'
 import { useRoom } from './yjs/useRoom'
 import { useScenes } from './yjs/useScenes'
+import type { Scene } from './yjs/useScenes'
 import { useWorld } from './yjs/useWorld'
 import { useEntities } from './entities/useEntities'
 import { useSceneTokens } from './combat/useSceneTokens'
@@ -27,6 +28,11 @@ import type { ShowcaseItem } from './showcase/showcaseTypes'
 import type { Entity } from './shared/entityTypes'
 import { defaultNPCPermissions } from './shared/permissions'
 import { getEntityResources, getEntityAttributes } from './shared/entityAdapters'
+import {
+  gcOrphanedEntities,
+  addEntityToAllScenes,
+  getPersistentEntityIds,
+} from './entities/entityLifecycle'
 import { HandoutEditModal } from './dock/HandoutEditModal'
 import { generateTokenId } from './shared/idUtils'
 import { TeamDashboard } from './team/TeamDashboard'
@@ -162,6 +168,43 @@ function RoomSession({ roomId }: { roomId: string }) {
     if (inspectedCharacterId === entityId) setInspectedCharacterId(null)
   }
 
+  // Delete scene + garbage-collect orphaned non-persistent entities
+  const handleDeleteScene = (sceneId: string) => {
+    const entityIds = getSceneEntityIds(sceneId)
+    deleteScene(sceneId)
+    yDoc.transact(() => {
+      const deleted = gcOrphanedEntities(entityIds, world.scenes, world.entities)
+      if (deleted.length > 0 && inspectedCharacterId && deleted.includes(inspectedCharacterId)) {
+        setInspectedCharacterId(null)
+      }
+    })
+  }
+
+  // Add scene with persistent entities auto-joined
+  const handleAddScene = (scene: Scene) => {
+    const persistentIds = getPersistentEntityIds(world.entities)
+    addScene(scene, persistentIds)
+  }
+
+  // Add entity — if persistent, auto-join all existing scenes
+  const handleAddEntity = (entity: Entity) => {
+    addEntity(entity)
+    if (entity.persistent) {
+      addEntityToAllScenes(entity.id, world.scenes)
+    }
+  }
+
+  // Update entity — if persistent toggled to true, auto-join all scenes
+  const handleUpdateEntity = (id: string, updates: Partial<Entity>) => {
+    if (updates.persistent === true) {
+      const existing = getEntity(id)
+      if (existing && !existing.persistent) {
+        addEntityToAllScenes(id, world.scenes)
+      }
+    }
+    updateEntity(id, updates)
+  }
+
   // Handle setting active character
   const handleSetActiveCharacter = (entityId: string) => {
     if (mySeatId) {
@@ -203,7 +246,7 @@ function RoomSession({ roomId }: { roomId: string }) {
       permissions: defaultNPCPermissions(),
       persistent: false,
     }
-    addEntity(newEntity)
+    handleAddEntity(newEntity)
     if (room.activeSceneId) addEntityToScene(room.activeSceneId, newEntity.id)
     setInspectedCharacterId(newEntity.id)
     setBgContextMenu(null)
@@ -243,14 +286,16 @@ function RoomSession({ roomId }: { roomId: string }) {
         onInspectCharacter={setInspectedCharacterId}
         onSetActiveCharacter={handleSetActiveCharacter}
         onRemoveFromScene={handleRemoveFromScene}
-        onUpdateEntity={updateEntity}
+        onUpdateEntity={handleUpdateEntity}
       />
 
       {/* Top-right: Team dashboard */}
       <TeamDashboard yDoc={yDoc} isGM={isGM} />
 
       {/* Left: My character card (self-managed open/close via tab) */}
-      {activeEntity && <MyCharacterCard entity={activeEntity} onUpdateEntity={updateEntity} />}
+      {activeEntity && (
+        <MyCharacterCard entity={activeEntity} onUpdateEntity={handleUpdateEntity} />
+      )}
 
       {/* Center: Showcase spotlight overlay */}
       <ShowcaseOverlay yDoc={yDoc} isGM={isGM} />
@@ -274,11 +319,11 @@ function RoomSession({ roomId }: { roomId: string }) {
           scenes={scenes}
           activeSceneId={room.activeSceneId}
           onSelectScene={setActiveScene}
-          onAddScene={addScene}
-          onDeleteScene={deleteScene}
+          onAddScene={handleAddScene}
+          onDeleteScene={handleDeleteScene}
           blueprints={world.blueprints}
           entities={entities}
-          onAddEntity={addEntity}
+          onAddEntity={handleAddEntity}
           onAddEntityToScene={(entityId) => {
             if (room.activeSceneId) addEntityToScene(room.activeSceneId, entityId)
           }}
@@ -306,9 +351,9 @@ function RoomSession({ roomId }: { roomId: string }) {
           onToggleCombat={() => {
             if (room.activeSceneId) setCombatActive(room.activeSceneId, !isCombat)
           }}
-          onAddScene={addScene}
+          onAddScene={handleAddScene}
           onUpdateScene={updateScene}
-          onDeleteScene={deleteScene}
+          onDeleteScene={handleDeleteScene}
         />
       )}
 

--- a/src/entities/__tests__/entityLifecycle.test.ts
+++ b/src/entities/__tests__/entityLifecycle.test.ts
@@ -1,0 +1,142 @@
+import * as Y from 'yjs'
+import {
+  gcOrphanedEntities,
+  addEntityToAllScenes,
+  getPersistentEntityIds,
+} from '../entityLifecycle'
+import { createTestDoc, addSceneToDoc } from '../../__test-utils__/yjs-helpers'
+
+/** Helper: add an entity Y.Map to the entities store */
+function addEntity(yDoc: Y.Doc, yEntities: Y.Map<Y.Map<unknown>>, id: string, persistent: boolean) {
+  yDoc.transact(() => {
+    const yMap = new Y.Map<unknown>()
+    yEntities.set(id, yMap)
+    yMap.set('id', id)
+    yMap.set('name', `Entity ${id}`)
+    yMap.set('persistent', persistent)
+  })
+}
+
+/** Helper: add an entity reference to a scene's entityIds */
+function addEntityToScene(yScenes: Y.Map<Y.Map<unknown>>, sceneId: string, entityId: string) {
+  const sceneMap = yScenes.get(sceneId) as Y.Map<unknown>
+  const entityIds = sceneMap.get('entityIds') as Y.Map<boolean>
+  entityIds.set(entityId, true)
+}
+
+describe('gcOrphanedEntities', () => {
+  it('deletes non-persistent entities not referenced by any remaining scene', () => {
+    const { yDoc, scenes, entities } = createTestDoc()
+    addSceneToDoc(scenes, yDoc, 'scene-1')
+    addSceneToDoc(scenes, yDoc, 'scene-2')
+    addEntity(yDoc, entities, 'e1', false)
+    addEntity(yDoc, entities, 'e2', false)
+    addEntityToScene(scenes, 'scene-1', 'e1')
+    addEntityToScene(scenes, 'scene-2', 'e1')
+    addEntityToScene(scenes, 'scene-2', 'e2')
+
+    // Delete scene-2 — e2 was only in scene-2
+    const deletedSceneEntityIds = ['e1', 'e2']
+    scenes.delete('scene-2')
+    const deleted = gcOrphanedEntities(deletedSceneEntityIds, scenes, entities)
+
+    expect(deleted).toEqual(['e2'])
+    expect(entities.has('e1')).toBe(true)
+    expect(entities.has('e2')).toBe(false)
+  })
+
+  it('keeps persistent entities even if unreferenced', () => {
+    const { yDoc, scenes, entities } = createTestDoc()
+    addSceneToDoc(scenes, yDoc, 'scene-1')
+    addEntity(yDoc, entities, 'e1', true) // persistent
+    addEntityToScene(scenes, 'scene-1', 'e1')
+
+    // Delete scene-1 — e1 is persistent so should NOT be GC'd
+    scenes.delete('scene-1')
+    const deleted = gcOrphanedEntities(['e1'], scenes, entities)
+
+    expect(deleted).toEqual([])
+    expect(entities.has('e1')).toBe(true)
+  })
+
+  it('keeps entities still referenced by other scenes', () => {
+    const { yDoc, scenes, entities } = createTestDoc()
+    addSceneToDoc(scenes, yDoc, 'scene-1')
+    addSceneToDoc(scenes, yDoc, 'scene-2')
+    addEntity(yDoc, entities, 'e1', false)
+    addEntityToScene(scenes, 'scene-1', 'e1')
+    addEntityToScene(scenes, 'scene-2', 'e1')
+
+    scenes.delete('scene-2')
+    const deleted = gcOrphanedEntities(['e1'], scenes, entities)
+
+    expect(deleted).toEqual([])
+    expect(entities.has('e1')).toBe(true)
+  })
+
+  it('returns empty array when no entities to check', () => {
+    const { yDoc, scenes, entities } = createTestDoc()
+    addSceneToDoc(scenes, yDoc, 'scene-1')
+
+    scenes.delete('scene-1')
+    const deleted = gcOrphanedEntities([], scenes, entities)
+
+    expect(deleted).toEqual([])
+  })
+
+  it('handles entity IDs that do not exist in entities store', () => {
+    const { yDoc, scenes, entities } = createTestDoc()
+    addSceneToDoc(scenes, yDoc, 'scene-1')
+
+    scenes.delete('scene-1')
+    const deleted = gcOrphanedEntities(['nonexistent'], scenes, entities)
+
+    expect(deleted).toEqual([])
+  })
+})
+
+describe('addEntityToAllScenes', () => {
+  it('adds entity to all existing scenes', () => {
+    const { yDoc, scenes } = createTestDoc()
+    addSceneToDoc(scenes, yDoc, 'scene-1')
+    addSceneToDoc(scenes, yDoc, 'scene-2')
+
+    addEntityToAllScenes('e1', scenes)
+
+    const ids1 = (scenes.get('scene-1') as Y.Map<unknown>).get('entityIds') as Y.Map<boolean>
+    const ids2 = (scenes.get('scene-2') as Y.Map<unknown>).get('entityIds') as Y.Map<boolean>
+    expect(ids1.has('e1')).toBe(true)
+    expect(ids2.has('e1')).toBe(true)
+  })
+
+  it('does nothing when no scenes exist', () => {
+    const { scenes } = createTestDoc()
+    // Should not throw
+    addEntityToAllScenes('e1', scenes)
+  })
+})
+
+describe('getPersistentEntityIds', () => {
+  it('returns IDs of persistent entities only', () => {
+    const { yDoc, entities } = createTestDoc()
+    addEntity(yDoc, entities, 'e1', true)
+    addEntity(yDoc, entities, 'e2', false)
+    addEntity(yDoc, entities, 'e3', true)
+
+    const ids = getPersistentEntityIds(entities)
+    expect(ids.sort()).toEqual(['e1', 'e3'])
+  })
+
+  it('returns empty array when no entities exist', () => {
+    const { entities } = createTestDoc()
+    expect(getPersistentEntityIds(entities)).toEqual([])
+  })
+
+  it('returns empty array when all entities are non-persistent', () => {
+    const { yDoc, entities } = createTestDoc()
+    addEntity(yDoc, entities, 'e1', false)
+    addEntity(yDoc, entities, 'e2', false)
+
+    expect(getPersistentEntityIds(entities)).toEqual([])
+  })
+})

--- a/src/entities/entityLifecycle.ts
+++ b/src/entities/entityLifecycle.ts
@@ -1,0 +1,64 @@
+import * as Y from 'yjs'
+
+/**
+ * After deleting a scene, garbage-collect non-persistent entities
+ * that are no longer referenced by any remaining scene.
+ * Call this AFTER the scene has been deleted from yScenes.
+ */
+export function gcOrphanedEntities(
+  deletedSceneEntityIds: string[],
+  yScenes: Y.Map<Y.Map<unknown>>,
+  yEntities: Y.Map<Y.Map<unknown>>,
+): string[] {
+  // Collect all entity IDs still referenced by remaining scenes
+  const referenced = new Set<string>()
+  yScenes.forEach((sceneMap) => {
+    if (!(sceneMap instanceof Y.Map)) return
+    const entityIds = sceneMap.get('entityIds')
+    if (entityIds instanceof Y.Map) {
+      entityIds.forEach((_val, key) => referenced.add(key))
+    }
+  })
+
+  // Delete non-persistent, unreferenced entities
+  const deleted: string[] = []
+  for (const id of deletedSceneEntityIds) {
+    if (referenced.has(id)) continue
+    const yMap = yEntities.get(id)
+    if (!(yMap instanceof Y.Map)) continue
+    const persistent = (yMap.get('persistent') as boolean) ?? false
+    if (!persistent) {
+      yEntities.delete(id)
+      deleted.push(id)
+    }
+  }
+  return deleted
+}
+
+/**
+ * Add an entity to all existing scenes' entityIds.
+ * Used when creating a persistent entity.
+ */
+export function addEntityToAllScenes(entityId: string, yScenes: Y.Map<Y.Map<unknown>>) {
+  yScenes.forEach((sceneMap) => {
+    if (!(sceneMap instanceof Y.Map)) return
+    const entityIds = sceneMap.get('entityIds')
+    if (entityIds instanceof Y.Map) {
+      entityIds.set(entityId, true)
+    }
+  })
+}
+
+/**
+ * Get IDs of all persistent entities from the global entities store.
+ */
+export function getPersistentEntityIds(yEntities: Y.Map<Y.Map<unknown>>): string[] {
+  const ids: string[] = []
+  yEntities.forEach((yMap, id) => {
+    if (!(yMap instanceof Y.Map)) return
+    if ((yMap.get('persistent') as boolean) === true) {
+      ids.push(id)
+    }
+  })
+  return ids
+}


### PR DESCRIPTION
## Summary
- 新增 `entityLifecycle.ts`：场景删除时 GC 非持久实体、持久实体自动加入所有场景
- `gcOrphanedEntities`：删除场景后清理不再被任何场景引用的非持久实体
- `addEntityToAllScenes`：持久实体创建/更新时自动加入所有现有场景
- `getPersistentEntityIds`：新建场景时获取所有持久实体 ID 以自动关联
- App.tsx 新增 `handleDeleteScene`、`handleAddScene`、`handleAddEntity`、`handleUpdateEntity` 包装函数
- 10 个单元测试覆盖全部生命周期函数

## Test Plan
- [x] 174 tests passing (10 new + 164 existing)
- [x] TypeScript compiles clean
- [x] ESLint passes