### PR TITLE
feat: LevelDB roster → entities migration

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -35,6 +35,17 @@ setPersistence({
     const persistedYdoc = await ldb.getYDoc(docName)
     const newUpdates = Y.encodeStateAsUpdate(persistedYdoc)
     Y.applyUpdate(ydoc, newUpdates)
+
+    // Migrate roster → entities (one-time, from pre-refactor data)
+    const roster = ydoc.getMap('roster')
+    const entities = ydoc.getMap('entities')
+    if (roster.size > 0 && entities.size === 0) {
+      ydoc.transact(() => {
+        roster.forEach((val, key) => entities.set(key, val))
+      })
+      console.log(`[migration] ${docName}: migrated ${roster.size} entries from roster → entities`)
+    }
+
     ydoc.on('update', (update) => {
       ldb.storeUpdate(docName, update)
     })


### PR DESCRIPTION
## Summary
- 服务端加载 Y.Doc 时自动迁移旧 `roster` 数据到新 `entities` top-level map
- 仅当 `roster` 有数据且 `entities` 为空时触发（一次性迁移）
- 保留 `roster` 原数据不删除，保持向下兼容

## Test Plan
- [x] 手动验证：无 roster 数据时不触发迁移
- [x] 代码审查：迁移逻辑在 `bindState` 中，确保在 update listener 注册前完成