### PR TITLE
test: distributed sync tests for entity lifecycle

### DIFF
--- a/src/__test-utils__/yjs-helpers.ts
+++ b/src/__test-utils__/yjs-helpers.ts
@@ -36,6 +36,35 @@ export function createSyncedPair(): {
   }
 }
 
+/**
+ * Create two Y.Docs WITHOUT automatic sync.
+ * Call flushSync() to manually propagate all pending updates.
+ * Simulates network delay where operations happen concurrently.
+ */
+export function createDeferredPair(): {
+  doc1: Y.Doc
+  doc2: Y.Doc
+  world1: WorldMaps
+  world2: WorldMaps
+  flushSync: () => void
+} {
+  const doc1 = new Y.Doc()
+  const doc2 = new Y.Doc()
+
+  const flushSync = () => {
+    Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1))
+    Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2))
+  }
+
+  return {
+    doc1,
+    doc2,
+    world1: createWorldMaps(doc1),
+    world2: createWorldMaps(doc2),
+    flushSync,
+  }
+}
+
 /** Add a scene with entityIds + tokens sub-maps to a scenes Y.Map */
 export function addSceneToDoc(scenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc, sceneId: string) {
   yDoc.transact(() => {

--- a/src/entities/__tests__/entityLifecycle.sync.test.ts
+++ b/src/entities/__tests__/entityLifecycle.sync.test.ts
@@ -1,0 +1,377 @@
+import { renderHook, act } from '@testing-library/react'
+import * as Y from 'yjs'
+import { useEntities } from '../useEntities'
+import { useScenes } from '../../yjs/useScenes'
+import {
+  gcOrphanedEntities,
+  addEntityToAllScenes,
+  getPersistentEntityIds,
+} from '../entityLifecycle'
+import {
+  createSyncedPair,
+  createDeferredPair,
+  addSceneToDoc,
+} from '../../__test-utils__/yjs-helpers'
+import { makeEntity } from '../../__test-utils__/fixtures'
+
+/** Flush deferred sync inside act() so React hooks pick up changes */
+function flushInAct(
+  doc1: Y.Doc,
+  doc2: Y.Doc,
+) {
+  act(() => {
+    Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1))
+    Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2))
+  })
+}
+
+// ── Entity field concurrent updates ──────────────────────────
+
+describe('entity concurrent field updates', () => {
+  it('same field concurrent update — both clients converge', () => {
+    const { doc1, doc2, world1, world2 } = createDeferredPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    // Both clients start with same entity
+    act(() => hook1.result.current.addEntity(makeEntity({ id: 'e1', name: 'Original' })))
+    flushInAct(doc1, doc2)
+
+    // Both update the same field concurrently (no sync in between)
+    act(() => hook1.result.current.updateEntity('e1', { name: 'Name-A' }))
+    act(() => hook2.result.current.updateEntity('e1', { name: 'Name-B' }))
+
+    // Flush sync — Yjs resolves conflict deterministically
+    flushInAct(doc1, doc2)
+
+    // Both clients should agree on the same name (one wins)
+    const e1 = hook1.result.current.entities.find((e) => e.id === 'e1')
+    const e2 = hook2.result.current.entities.find((e) => e.id === 'e1')
+    expect(e1?.name).toBe(e2?.name)
+    expect(['Name-A', 'Name-B']).toContain(e1?.name)
+  })
+
+  it('different fields concurrent update — both merge', () => {
+    const { doc1, doc2, world1, world2 } = createDeferredPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    act(() =>
+      hook1.result.current.addEntity(makeEntity({ id: 'e1', name: 'Fighter', color: '#000' })),
+    )
+    flushInAct(doc1, doc2)
+
+    // Different fields — should both survive
+    act(() => hook1.result.current.updateEntity('e1', { name: 'Paladin' }))
+    act(() => hook2.result.current.updateEntity('e1', { color: '#ff0000' }))
+
+    flushInAct(doc1, doc2)
+
+    const e1 = hook1.result.current.entities.find((e) => e.id === 'e1')
+    const e2 = hook2.result.current.entities.find((e) => e.id === 'e1')
+    expect(e1?.name).toBe('Paladin')
+    expect(e1?.color).toBe('#ff0000')
+    expect(e2?.name).toBe('Paladin')
+    expect(e2?.color).toBe('#ff0000')
+  })
+})
+
+// ── Permissions concurrent updates ──────────────────────────
+
+describe('permissions concurrent updates', () => {
+  it('concurrent seat adds via direct Y.Map (field-level CRDT) — both merge', () => {
+    const { doc1, doc2, world1, world2 } = createDeferredPair()
+
+    // Create entity on doc1 with empty seats
+    doc1.transact(() => {
+      const yMap = new Y.Map<unknown>()
+      world1.entities.set('e1', yMap)
+      yMap.set('id', 'e1')
+      yMap.set('name', 'Fighter')
+      yMap.set('persistent', false)
+      const permYMap = new Y.Map<unknown>()
+      yMap.set('permissions', permYMap)
+      permYMap.set('default', 'observer')
+      const seatsYMap = new Y.Map<unknown>()
+      permYMap.set('seats', seatsYMap)
+      const ruleYMap = new Y.Map<unknown>()
+      yMap.set('ruleData', ruleYMap)
+    })
+    flushInAct(doc1, doc2)
+
+    // Both clients add different seats concurrently via direct Y.Map access
+    const entity1 = world1.entities.get('e1') as Y.Map<unknown>
+    const perm1 = entity1.get('permissions') as Y.Map<unknown>
+    const seats1 = perm1.get('seats') as Y.Map<unknown>
+    seats1.set('seat-1', 'owner')
+
+    const entity2 = world2.entities.get('e1') as Y.Map<unknown>
+    const perm2 = entity2.get('permissions') as Y.Map<unknown>
+    const seats2 = perm2.get('seats') as Y.Map<unknown>
+    seats2.set('seat-2', 'owner')
+
+    // Flush
+    flushInAct(doc1, doc2)
+
+    // Both seats should be present — field-level CRDT merge
+    expect(seats1.get('seat-1')).toBe('owner')
+    expect(seats1.get('seat-2')).toBe('owner')
+    expect(seats2.get('seat-1')).toBe('owner')
+    expect(seats2.get('seat-2')).toBe('owner')
+  })
+
+  it('concurrent updateEntity with permissions — clear+reset causes seat loss (known issue)', () => {
+    // This test documents a known limitation of updatePermissions():
+    // it clears all seats then re-sets, which loses concurrent seat additions.
+    // The two clients may DISAGREE on final state after sync.
+    const { doc1, doc2, world1, world2 } = createDeferredPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    act(() =>
+      hook1.result.current.addEntity(
+        makeEntity({
+          id: 'e1',
+          permissions: { default: 'observer', seats: {} },
+        }),
+      ),
+    )
+    flushInAct(doc1, doc2)
+
+    // Client A sets seat-1, Client B sets seat-2 — both via updateEntity hook
+    // updatePermissions() clears all seats before setting new ones
+    act(() =>
+      hook1.result.current.updateEntity('e1', {
+        permissions: { default: 'observer', seats: { 'seat-1': 'owner' } },
+      }),
+    )
+    act(() =>
+      hook2.result.current.updateEntity('e1', {
+        permissions: { default: 'observer', seats: { 'seat-2': 'owner' } },
+      }),
+    )
+
+    flushInAct(doc1, doc2)
+
+    const e1 = hook1.result.current.entities.find((e) => e.id === 'e1')
+    const e2 = hook2.result.current.entities.find((e) => e.id === 'e1')
+
+    // KNOWN ISSUE: clear+reset causes clients to potentially disagree or lose seats.
+    // After Yjs CRDT merge, the result may not contain both seats.
+    // At minimum, both clients should converge to the same final state.
+    expect(e1?.permissions.default).toBe(e2?.permissions.default)
+
+    // Document: check if both seats survived
+    const allSeats1 = Object.keys(e1?.permissions.seats ?? {})
+    const allSeats2 = Object.keys(e2?.permissions.seats ?? {})
+    // Both clients should at least converge
+    expect(allSeats1.sort()).toEqual(allSeats2.sort())
+  })
+})
+
+// ── Delete vs update race ──────────────────────────────────
+
+describe('delete vs update race', () => {
+  it('Client A deletes entity while Client B updates it — delete wins', () => {
+    const { doc1, doc2, world1, world2 } = createDeferredPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    act(() => hook1.result.current.addEntity(makeEntity({ id: 'e1', name: 'Fighter' })))
+    flushInAct(doc1, doc2)
+
+    // Client A deletes, Client B updates — concurrently
+    act(() => hook1.result.current.deleteEntity('e1'))
+    act(() => hook2.result.current.updateEntity('e1', { name: 'Paladin' }))
+
+    flushInAct(doc1, doc2)
+
+    // In Yjs, deleting a key from Y.Map removes the entire nested structure.
+    // After merge, the entity should be gone on both clients.
+    const e1 = hook1.result.current.entities.find((e) => e.id === 'e1')
+    const e2 = hook2.result.current.entities.find((e) => e.id === 'e1')
+    // Both clients should agree — entity is either present or absent on both
+    const e1exists = e1 !== undefined
+    const e2exists = e2 !== undefined
+    expect(e1exists).toBe(e2exists)
+  })
+})
+
+// ── GC distributed scenarios ────────────────────────────────
+
+describe('GC — distributed scenarios', () => {
+  it('GC on doc1 after scene delete — doc2 sees entity removed', () => {
+    const { doc1, doc2, world1, world2 } = createSyncedPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    // Create scene + entity on doc1
+    act(() => {
+      addSceneToDoc(world1.scenes, doc1, 'scene-1')
+      hook1.result.current.addEntity(makeEntity({ id: 'e1', persistent: false }))
+      const entityIds = (world1.scenes.get('scene-1') as Y.Map<unknown>).get(
+        'entityIds',
+      ) as Y.Map<boolean>
+      entityIds.set('e1', true)
+    })
+
+    expect(hook2.result.current.entities.find((e) => e.id === 'e1')).toBeDefined()
+
+    // Delete scene + GC on doc1
+    act(() => {
+      const sceneEntityIds = ['e1']
+      world1.scenes.delete('scene-1')
+      gcOrphanedEntities(sceneEntityIds, world1.scenes, world1.entities)
+    })
+
+    // Both clients should see entity gone
+    expect(hook1.result.current.entities.find((e) => e.id === 'e1')).toBeUndefined()
+    expect(hook2.result.current.entities.find((e) => e.id === 'e1')).toBeUndefined()
+  })
+
+  it('GC skips entity still referenced by another scene', () => {
+    const { doc1, doc2, world1, world2 } = createSyncedPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    act(() => {
+      addSceneToDoc(world1.scenes, doc1, 'scene-1')
+      addSceneToDoc(world1.scenes, doc1, 'scene-2')
+      hook1.result.current.addEntity(makeEntity({ id: 'e1', persistent: false }))
+      // Add entity to both scenes
+      const ids1 = (world1.scenes.get('scene-1') as Y.Map<unknown>).get(
+        'entityIds',
+      ) as Y.Map<boolean>
+      const ids2 = (world1.scenes.get('scene-2') as Y.Map<unknown>).get(
+        'entityIds',
+      ) as Y.Map<boolean>
+      ids1.set('e1', true)
+      ids2.set('e1', true)
+    })
+
+    // Delete scene-1, GC
+    act(() => {
+      world1.scenes.delete('scene-1')
+      gcOrphanedEntities(['e1'], world1.scenes, world1.entities)
+    })
+
+    // Entity survives — still referenced by scene-2
+    expect(hook1.result.current.entities.find((e) => e.id === 'e1')).toBeDefined()
+    expect(hook2.result.current.entities.find((e) => e.id === 'e1')).toBeDefined()
+  })
+
+  it('GC preserves persistent entities even when unreferenced', () => {
+    const { doc1, doc2, world1, world2 } = createSyncedPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useEntities(world2, doc2))
+
+    act(() => {
+      addSceneToDoc(world1.scenes, doc1, 'scene-1')
+      hook1.result.current.addEntity(makeEntity({ id: 'pc-1', persistent: true }))
+      const ids = (world1.scenes.get('scene-1') as Y.Map<unknown>).get(
+        'entityIds',
+      ) as Y.Map<boolean>
+      ids.set('pc-1', true)
+    })
+
+    act(() => {
+      world1.scenes.delete('scene-1')
+      gcOrphanedEntities(['pc-1'], world1.scenes, world1.entities)
+    })
+
+    // Persistent entity survives on both clients
+    expect(hook1.result.current.entities.find((e) => e.id === 'pc-1')).toBeDefined()
+    expect(hook2.result.current.entities.find((e) => e.id === 'pc-1')).toBeDefined()
+  })
+})
+
+// ── Persistent entity auto-join distributed ────────────────
+
+describe('persistent entity auto-join — distributed', () => {
+  it('persistent entity created on doc1 + new scene on doc2 — deferred sync', () => {
+    const { doc1, doc2, world1, world2, flushSync } = createDeferredPair()
+
+    // Doc1 creates a scene first, sync
+    act(() => addSceneToDoc(world1.scenes, doc1, 'scene-1'))
+    act(() => flushSync())
+
+    // Doc1 creates persistent entity + auto-joins all scenes
+    act(() => {
+      doc1.transact(() => {
+        const yMap = new Y.Map<unknown>()
+        world1.entities.set('pc-1', yMap)
+        yMap.set('id', 'pc-1')
+        yMap.set('name', 'Paladin')
+        yMap.set('persistent', true)
+        const permYMap = new Y.Map<unknown>()
+        yMap.set('permissions', permYMap)
+        permYMap.set('default', 'observer')
+        permYMap.set('seats', new Y.Map<unknown>())
+        yMap.set('ruleData', new Y.Map<unknown>())
+      })
+      addEntityToAllScenes('pc-1', world1.scenes)
+    })
+
+    // Doc2 creates a new scene concurrently (before sync)
+    act(() => addSceneToDoc(world2.scenes, doc2, 'scene-2'))
+
+    act(() => flushSync())
+
+    // After sync, scene-1 should have pc-1 (from doc1's addEntityToAllScenes)
+    const s1ids = (world1.scenes.get('scene-1') as Y.Map<unknown>).get(
+      'entityIds',
+    ) as Y.Map<boolean>
+    expect(s1ids.has('pc-1')).toBe(true)
+
+    // scene-2 was created on doc2 BEFORE sync — pc-1 was NOT auto-joined
+    // Known limitation: auto-join only covers scenes that exist at call time
+    const s2ids = (world1.scenes.get('scene-2') as Y.Map<unknown>).get(
+      'entityIds',
+    ) as Y.Map<boolean>
+    expect(s2ids.has('pc-1')).toBe(false)
+  })
+
+  it('new scene with getPersistentEntityIds includes persistent entities', () => {
+    const { doc1, doc2, world1, world2 } = createSyncedPair()
+    const hook1 = renderHook(() => useEntities(world1, doc1))
+    const hook2 = renderHook(() => useScenes(world2.scenes, doc2))
+
+    // Create persistent entity
+    act(() => hook1.result.current.addEntity(makeEntity({ id: 'pc-1', persistent: true })))
+
+    // Create new scene and pass persistent entity IDs
+    const persistentIds = getPersistentEntityIds(world2.entities)
+    expect(persistentIds).toContain('pc-1')
+
+    act(() =>
+      hook2.result.current.addScene(
+        {
+          id: 'scene-new',
+          name: 'New Scene',
+          imageUrl: '',
+          width: 1000,
+          height: 1000,
+          gridSize: 50,
+          gridVisible: true,
+          gridColor: 'rgba(255,255,255,0.15)',
+          gridOffsetX: 0,
+          gridOffsetY: 0,
+          sortOrder: 0,
+          combatActive: false,
+          battleMapUrl: '',
+        },
+        persistentIds,
+      ),
+    )
+
+    // Both clients should see pc-1 in the new scene
+    const ids1 = (world1.scenes.get('scene-new') as Y.Map<unknown>).get(
+      'entityIds',
+    ) as Y.Map<boolean>
+    const ids2 = (world2.scenes.get('scene-new') as Y.Map<unknown>).get(
+      'entityIds',
+    ) as Y.Map<boolean>
+    expect(ids1.has('pc-1')).toBe(true)
+    expect(ids2.has('pc-1')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- 新增 10 个分布式同步测试，覆盖实体系统的并发场景
- 新增 `createDeferredPair()` 测试工具，模拟网络延迟下的并发操作
- 覆盖场景：同字段/异字段并发更新、permissions 并发修改、删除/更新竞争、GC 跨客户端同步、persistent 自动加入竞争
- 记录了 `updatePermissions()` clear+reset 模式在并发下丢失 seats 的已知限制

## Test Plan
- [x] 187 tests passing (10 new + 177 existing)