### PR TITLE
fix: concurrent permissions update seat loss

### DIFF
--- a/src/entities/__tests__/entityLifecycle.sync.test.ts
+++ b/src/entities/__tests__/entityLifecycle.sync.test.ts
@@ -120,10 +120,7 @@ describe('permissions concurrent updates', () => {
     expect(seats2.get('seat-2')).toBe('owner')
   })
 
-  it('concurrent updateEntity with permissions — clear+reset causes seat loss (known issue)', () => {
-    // This test documents a known limitation of updatePermissions():
-    // it clears all seats then re-sets, which loses concurrent seat additions.
-    // The two clients may DISAGREE on final state after sync.
+  it('concurrent updateEntity with different seats — both survive after CRDT merge', () => {
     const { doc1, doc2, world1, world2 } = createDeferredPair()
     const hook1 = renderHook(() => useEntities(world1, doc1))
     const hook2 = renderHook(() => useEntities(world2, doc2))
@@ -139,7 +136,6 @@ describe('permissions concurrent updates', () => {
     flushInAct(doc1, doc2)
 
     // Client A sets seat-1, Client B sets seat-2 — both via updateEntity hook
-    // updatePermissions() clears all seats before setting new ones
     act(() =>
       hook1.result.current.updateEntity('e1', {
         permissions: { default: 'observer', seats: { 'seat-1': 'owner' } },
@@ -156,16 +152,12 @@ describe('permissions concurrent updates', () => {
     const e1 = hook1.result.current.entities.find((e) => e.id === 'e1')
     const e2 = hook2.result.current.entities.find((e) => e.id === 'e1')
 
-    // KNOWN ISSUE: clear+reset causes clients to potentially disagree or lose seats.
-    // After Yjs CRDT merge, the result may not contain both seats.
-    // At minimum, both clients should converge to the same final state.
-    expect(e1?.permissions.default).toBe(e2?.permissions.default)
+    // Both clients should converge to the same state
+    expect(e1?.permissions).toEqual(e2?.permissions)
 
-    // Document: check if both seats survived
-    const allSeats1 = Object.keys(e1?.permissions.seats ?? {})
-    const allSeats2 = Object.keys(e2?.permissions.seats ?? {})
-    // Both clients should at least converge
-    expect(allSeats1.sort()).toEqual(allSeats2.sort())
+    // Both seats should survive — each client only deletes seats not in its own update
+    expect(e1?.permissions.seats['seat-1']).toBe('owner')
+    expect(e1?.permissions.seats['seat-2']).toBe('owner')
   })
 })
 

--- a/src/entities/useEntities.ts
+++ b/src/entities/useEntities.ts
@@ -95,8 +95,11 @@ function updatePermissions(entityYMap: Y.Map<unknown>, permissions: EntityPermis
     permYMap.set('default', permissions.default)
     const seatsYMap = permYMap.get('seats')
     if (seatsYMap instanceof Y.Map) {
-      // Clear existing seats and set new ones
-      seatsYMap.forEach((_v, k) => seatsYMap.delete(k))
+      // Delete seats not in the new set, upsert seats that are
+      const newSeatIds = new Set(Object.keys(permissions.seats))
+      seatsYMap.forEach((_v, k) => {
+        if (!newSeatIds.has(k)) seatsYMap.delete(k)
+      })
       for (const [seatId, level] of Object.entries(permissions.seats)) {
         seatsYMap.set(seatId, level)
       }


### PR DESCRIPTION
## Summary
- 修复 `updatePermissions()` 在并发场景下丢失 seat 的 bug
- 原逻辑：清空所有 seats → 写入新 seats（并发添加的 seat 会被清空）
- 新逻辑：只删除不在新集合中的 seats → 写入/更新新 seats
- 更新分布式同步测试验证修复效果

## Test Plan
- [x] 187 tests passing
- [x] 并发 seat 添加测试通过（两个客户端各加一个 seat，合并后两个都保留）