### PR TITLE
test: improve coverage for useScenes, useEntities, useSceneTokens

### DIFF
--- a/src/combat/__tests__/useSceneTokens.test.ts
+++ b/src/combat/__tests__/useSceneTokens.test.ts
@@ -1,0 +1,99 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSceneTokens } from '../useSceneTokens'
+import { createTestDoc, addSceneToDoc } from '../../__test-utils__/yjs-helpers'
+import { makeToken } from '../../__test-utils__/fixtures'
+
+describe('useSceneTokens — single client', () => {
+  const sceneId = 'scene-1'
+
+  function setup(sid: string | null = sceneId) {
+    const { yDoc, ...world } = createTestDoc()
+    if (sid) addSceneToDoc(world.scenes, yDoc, sid)
+    const hook = renderHook(() => useSceneTokens(world, sid))
+    return { yDoc, world, hook }
+  }
+
+  // ── null sceneId path ───────────────────────────────────────
+
+  it('returns empty tokens when sceneId is null', () => {
+    const { hook } = setup(null)
+    expect(hook.result.current.tokens).toEqual([])
+  })
+
+  it('addToken is a no-op when sceneId is null', () => {
+    const { hook } = setup(null)
+    // Should not throw
+    act(() => hook.result.current.addToken(makeToken({ id: 'tok-1' })))
+    expect(hook.result.current.tokens).toEqual([])
+  })
+
+  // ── CRUD ────────────────────────────────────────────────────
+
+  it('adds and reads a token', () => {
+    const { hook } = setup()
+    const token = makeToken({ id: 'tok-1', x: 50, y: 75 })
+
+    act(() => hook.result.current.addToken(token))
+
+    expect(hook.result.current.tokens).toHaveLength(1)
+    expect(hook.result.current.tokens[0].id).toBe('tok-1')
+    expect(hook.result.current.tokens[0].x).toBe(50)
+  })
+
+  it('updates an existing token', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addToken(makeToken({ id: 'tok-1', x: 100, y: 200 })))
+
+    act(() => hook.result.current.updateToken('tok-1', { x: 300 }))
+
+    expect(hook.result.current.tokens[0].x).toBe(300)
+    expect(hook.result.current.tokens[0].y).toBe(200) // unchanged
+  })
+
+  it('updateToken no-ops for nonexistent token', () => {
+    const { hook } = setup()
+    // Should not throw
+    act(() => hook.result.current.updateToken('nope', { x: 999 }))
+    expect(hook.result.current.tokens).toHaveLength(0)
+  })
+
+  it('updateToken no-ops when sceneId is null', () => {
+    const { hook } = setup(null)
+    act(() => hook.result.current.updateToken('tok-1', { x: 999 }))
+    expect(hook.result.current.tokens).toEqual([])
+  })
+
+  it('deletes a token', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addToken(makeToken({ id: 'tok-1' })))
+    expect(hook.result.current.tokens).toHaveLength(1)
+
+    act(() => hook.result.current.deleteToken('tok-1'))
+
+    expect(hook.result.current.tokens).toHaveLength(0)
+  })
+
+  // ── getToken ──────────────────────────────────────────────
+
+  it('getToken returns a token by id', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addToken(makeToken({ id: 'tok-1', x: 42 })))
+
+    expect(hook.result.current.getToken('tok-1')?.x).toBe(42)
+  })
+
+  it('getToken returns null for null id', () => {
+    const { hook } = setup()
+    expect(hook.result.current.getToken(null)).toBeNull()
+  })
+
+  it('getToken returns null for nonexistent id', () => {
+    const { hook } = setup()
+    expect(hook.result.current.getToken('nope')).toBeNull()
+  })
+
+  it('getToken returns null when sceneId is null', () => {
+    const { hook } = setup(null)
+    expect(hook.result.current.getToken('tok-1')).toBeNull()
+  })
+})

--- a/src/entities/__tests__/useEntities.test.ts
+++ b/src/entities/__tests__/useEntities.test.ts
@@ -211,6 +211,124 @@ describe('useEntities', () => {
     expect(ruleData.resources).toEqual({ hp: { cur: 5, max: 10 } })
   })
 
+  // ── fallback branches ──────────────────────────────────────
+
+  it('readPermissions returns default when permissions is not a Y.Map', () => {
+    const { hook, world, yDoc } = setup()
+    // Manually create entity with permissions as a plain string (not Y.Map)
+    act(() => {
+      yDoc.transact(() => {
+        const yMap = new Y.Map<unknown>()
+        world.entities.set('bad-1', yMap)
+        yMap.set('id', 'bad-1')
+        yMap.set('name', 'Broken')
+        yMap.set('imageUrl', '')
+        yMap.set('color', '')
+        yMap.set('size', 1)
+        yMap.set('notes', '')
+        yMap.set('persistent', false)
+        yMap.set('ruleData', new Y.Map())
+        yMap.set('permissions', 'not-a-ymap') // plain value, not Y.Map
+      })
+    })
+
+    const found = hook.result.current.entities.find((e) => e.id === 'bad-1')
+    expect(found?.permissions).toEqual({ default: 'observer', seats: {} })
+  })
+
+  it('readRuleData returns null when ruleData is not a Y.Map', () => {
+    const { hook, world, yDoc } = setup()
+    act(() => {
+      yDoc.transact(() => {
+        const yMap = new Y.Map<unknown>()
+        world.entities.set('bad-2', yMap)
+        yMap.set('id', 'bad-2')
+        yMap.set('name', 'Broken')
+        yMap.set('imageUrl', '')
+        yMap.set('color', '')
+        yMap.set('size', 1)
+        yMap.set('notes', '')
+        yMap.set('persistent', false)
+        yMap.set('ruleData', 'not-a-ymap')
+        const permYMap = new Y.Map<unknown>()
+        yMap.set('permissions', permYMap)
+        permYMap.set('default', 'observer')
+        permYMap.set('seats', new Y.Map())
+      })
+    })
+
+    const found = hook.result.current.entities.find((e) => e.id === 'bad-2')
+    expect(found?.ruleData).toBeNull()
+  })
+
+  it('updatePermissions falls back to writePermissions when permissions is not Y.Map', () => {
+    const { hook, world, yDoc } = setup()
+    // Create entity with permissions as plain value
+    act(() => {
+      yDoc.transact(() => {
+        const yMap = new Y.Map<unknown>()
+        world.entities.set('bad-3', yMap)
+        yMap.set('id', 'bad-3')
+        yMap.set('name', 'Broken')
+        yMap.set('imageUrl', '')
+        yMap.set('color', '')
+        yMap.set('size', 1)
+        yMap.set('notes', '')
+        yMap.set('persistent', false)
+        yMap.set('ruleData', new Y.Map())
+        yMap.set('permissions', 'not-a-ymap')
+      })
+    })
+
+    // updateEntity should fix it via fallback writePermissions
+    act(() =>
+      hook.result.current.updateEntity('bad-3', {
+        permissions: { default: 'none', seats: { 'seat-1': 'owner' } },
+      }),
+    )
+
+    const found = hook.result.current.getEntity('bad-3')
+    expect(found?.permissions).toEqual({ default: 'none', seats: { 'seat-1': 'owner' } })
+  })
+
+  it('updateRuleData falls back to writeRuleData when ruleData is not Y.Map', () => {
+    const { hook, world, yDoc } = setup()
+    act(() => {
+      yDoc.transact(() => {
+        const yMap = new Y.Map<unknown>()
+        world.entities.set('bad-4', yMap)
+        yMap.set('id', 'bad-4')
+        yMap.set('name', 'Broken')
+        yMap.set('imageUrl', '')
+        yMap.set('color', '')
+        yMap.set('size', 1)
+        yMap.set('notes', '')
+        yMap.set('persistent', false)
+        yMap.set('ruleData', 'not-a-ymap')
+        const permYMap = new Y.Map<unknown>()
+        yMap.set('permissions', permYMap)
+        permYMap.set('default', 'observer')
+        permYMap.set('seats', new Y.Map())
+      })
+    })
+
+    act(() =>
+      hook.result.current.updateEntity('bad-4', {
+        ruleData: { kind: 'npc', level: 1 },
+      }),
+    )
+
+    const found = hook.result.current.getEntity('bad-4')
+    expect(found?.ruleData).toEqual({ kind: 'npc', level: 1 })
+  })
+
+  it('updateEntity no-ops for nonexistent entity', () => {
+    const { hook } = setup()
+    // Should not throw
+    act(() => hook.result.current.updateEntity('nonexistent', { name: 'Ghost' }))
+    expect(hook.result.current.entities).toHaveLength(0)
+  })
+
   it('concurrent permissions updates on different seats merge correctly', () => {
     const doc1 = new Y.Doc()
     const doc2 = new Y.Doc()

--- a/src/yjs/__tests__/useScenes.test.ts
+++ b/src/yjs/__tests__/useScenes.test.ts
@@ -125,4 +125,99 @@ describe('useScenes', () => {
     const { hook } = setup()
     expect(hook.result.current.getScene('nope')).toBeNull()
   })
+
+  // ── addEntityToScene / removeEntityFromScene ──────────────────
+
+  it('adds an entity to a scene', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addScene(makeScene({ id: 'sc-1' })))
+
+    act(() => hook.result.current.addEntityToScene('sc-1', 'ent-1'))
+
+    expect(hook.result.current.getSceneEntityIds('sc-1')).toContain('ent-1')
+  })
+
+  it('removes an entity from a scene', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addScene(makeScene({ id: 'sc-1' })))
+    act(() => hook.result.current.addEntityToScene('sc-1', 'ent-1'))
+    expect(hook.result.current.getSceneEntityIds('sc-1')).toContain('ent-1')
+
+    act(() => hook.result.current.removeEntityFromScene('sc-1', 'ent-1'))
+
+    expect(hook.result.current.getSceneEntityIds('sc-1')).not.toContain('ent-1')
+  })
+
+  it('no-ops addEntityToScene for nonexistent scene', () => {
+    const { hook } = setup()
+    // Should not throw
+    act(() => hook.result.current.addEntityToScene('no-scene', 'ent-1'))
+  })
+
+  it('no-ops removeEntityFromScene for nonexistent scene', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.removeEntityFromScene('no-scene', 'ent-1'))
+  })
+
+  // ── getSceneEntityIds ─────────────────────────────────────────
+
+  it('returns empty array for nonexistent scene', () => {
+    const { hook } = setup()
+    expect(hook.result.current.getSceneEntityIds('nope')).toEqual([])
+  })
+
+  it('returns multiple entity IDs', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addScene(makeScene({ id: 'sc-1' })))
+    act(() => {
+      hook.result.current.addEntityToScene('sc-1', 'ent-1')
+      hook.result.current.addEntityToScene('sc-1', 'ent-2')
+      hook.result.current.addEntityToScene('sc-1', 'ent-3')
+    })
+
+    const ids = hook.result.current.getSceneEntityIds('sc-1')
+    expect(ids).toHaveLength(3)
+    expect(ids).toContain('ent-1')
+    expect(ids).toContain('ent-2')
+    expect(ids).toContain('ent-3')
+  })
+
+  // ── setCombatActive ───────────────────────────────────────────
+
+  it('sets combatActive on a scene', () => {
+    const { hook } = setup()
+    act(() => hook.result.current.addScene(makeScene({ id: 'sc-1' })))
+    expect(hook.result.current.getScene('sc-1')?.combatActive).toBe(false)
+
+    act(() => hook.result.current.setCombatActive('sc-1', true))
+
+    expect(hook.result.current.getScene('sc-1')?.combatActive).toBe(true)
+  })
+
+  it('no-ops setCombatActive for nonexistent scene', () => {
+    const { hook } = setup()
+    // Should not throw
+    act(() => hook.result.current.setCombatActive('no-scene', true))
+  })
+
+  // ── addScene with persistentEntityIds ─────────────────────────
+
+  it('adds persistent entity IDs when creating a scene', () => {
+    const { hook } = setup()
+    const scene = makeScene({ id: 'sc-1' })
+
+    act(() => hook.result.current.addScene(scene, ['ent-a', 'ent-b']))
+
+    const ids = hook.result.current.getSceneEntityIds('sc-1')
+    expect(ids).toContain('ent-a')
+    expect(ids).toContain('ent-b')
+  })
+
+  // ── updateScene no-op for nonexistent ─────────────────────────
+
+  it('no-ops updateScene for nonexistent scene', () => {
+    const { hook } = setup()
+    // Should not throw
+    act(() => hook.result.current.updateScene('no-scene', { name: 'Gone' }))
+  })
 })


### PR DESCRIPTION
## Summary
- **useScenes.ts**: 69.86% → 100% line coverage. Added tests for `addEntityToScene`, `removeEntityFromScene`, `getSceneEntityIds`, `setCombatActive`, `addScene` with `persistentEntityIds`, and no-op edge cases
- **useEntities.ts**: 95.4% → 100% line coverage. Added fallback branch tests for `readPermissions`, `readRuleData`, `updatePermissions`, `updateRuleData` when stored data is not a Y.Map
- **useSceneTokens.ts**: 84.37% → 96.87% line coverage. Added single-client CRUD tests, null sceneId handling, and `getToken` edge cases

## Test plan
- [x] All 213 tests passing
- [x] Coverage verified via `vitest --coverage`