### PR TITLE
feat: add zustand stores as Yjs→React bridge layer (WP-0B)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-zoom-pan-pinch": "^3.7.0",
         "y-leveldb": "^0.2.0",
         "y-websocket": "^2.1.0",
-        "yjs": "^13.6.29"
+        "yjs": "^13.6.29",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -2083,7 +2084,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3440,7 +3441,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -7878,6 +7879,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-zoom-pan-pinch": "^3.7.0",
     "y-leveldb": "^0.2.0",
     "y-websocket": "^2.1.0",
-    "yjs": "^13.6.29"
+    "yjs": "^13.6.29",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,23 @@
 import { useEffect, useState } from 'react'
 import { useYjsConnection } from './yjs/useYjsConnection'
 import { AdminPanel } from './admin/AdminPanel'
-import { useRoom } from './yjs/useRoom'
-import { useScenes } from './yjs/useScenes'
-import type { Scene } from './yjs/useScenes'
+import { useWorldStore } from './stores/worldStore'
+import type { Scene, HandoutAsset } from './stores/worldStore'
+import { useIdentityStore } from './stores/identityStore'
+import { useUiStore } from './stores/uiStore'
+import {
+  selectActiveScene,
+  selectIsCombat,
+  deriveSeatProperties,
+  selectSpeakerEntities,
+} from './stores/selectors'
 import { useWorld } from './yjs/useWorld'
-import { useEntities } from './entities/useEntities'
-import { useSceneTokens } from './combat/useSceneTokens'
-import { SeatSelect } from './identity/SeatSelect'
-import { useIdentity } from './identity/useIdentity'
 import { roleStore } from './shared/roleState'
+import { SeatSelect } from './identity/SeatSelect'
 import { ChatPanel } from './chat/ChatPanel'
 import { SceneViewer } from './scene/SceneViewer'
 import { CombatViewer } from './combat/CombatViewer'
 import { BottomDock } from './dock/BottomDock'
-import { useHandoutAssets } from './dock/useHandoutAssets'
-import type { HandoutAsset } from './dock/useHandoutAssets'
 
 import { GmToolbar } from './gm/GmToolbar'
 import { HamburgerMenu } from './layout/HamburgerMenu'
@@ -23,11 +25,9 @@ import { PortraitBar } from './layout/PortraitBar'
 import { MyCharacterCard } from './layout/MyCharacterCard'
 import { ContextMenu } from './shared/ContextMenu'
 import { ShowcaseOverlay } from './showcase/ShowcaseOverlay'
-import { useShowcase } from './showcase/useShowcase'
 import type { ShowcaseItem } from './showcase/showcaseTypes'
 import type { Entity } from './shared/entityTypes'
 import { defaultNPCPermissions } from './shared/permissions'
-import { getEntityResources, getEntityAttributes } from './shared/entityAdapters'
 import {
   gcOrphanedEntities,
   addEntityToAllScenes,
@@ -40,62 +40,89 @@ import { TeamDashboard } from './team/TeamDashboard'
 function RoomSession({ roomId }: { roomId: string }) {
   const { yDoc, isLoading, awareness } = useYjsConnection(roomId)
   const world = useWorld(yDoc)
-  const {
-    seats,
-    mySeat,
-    mySeatId,
-    onlineSeatIds,
-    claimSeat,
-    createSeat,
-    deleteSeat,
-    leaveSeat,
-    updateSeat,
-  } = useIdentity(world.seats, awareness)
-  const { room, setActiveScene } = useRoom(world.room)
-  const {
-    scenes,
-    addScene,
-    updateScene,
-    deleteScene,
-    getScene,
-    addEntityToScene,
-    removeEntityFromScene,
-    getSceneEntityIds,
-    setCombatActive,
-  } = useScenes(world.scenes, yDoc)
 
-  const { entities, addEntity, updateEntity, getEntity } = useEntities(world, yDoc)
+  // Initialize stores with Yjs data
+  const initWorld = useWorldStore((s) => s.init)
+  const initIdentity = useIdentityStore((s) => s.init)
 
-  const activeScene = getScene(room.activeSceneId)
-  const isCombat = activeScene?.combatActive ?? false
-  const combatSceneId = isCombat ? room.activeSceneId : null
-  const { tokens, addToken, updateToken, deleteToken, getToken } = useSceneTokens(
-    world,
-    combatSceneId,
-  )
+  useEffect(() => {
+    const cleanupWorld = initWorld(yDoc)
+    const cleanupIdentity = initIdentity(world.seats, awareness)
+    return () => {
+      cleanupWorld()
+      cleanupIdentity()
+    }
+  }, [yDoc, awareness, world.seats, initWorld, initIdentity])
 
-  const { addItem: addShowcaseItem } = useShowcase(yDoc)
-  const {
-    assets: handoutAssets,
-    addAsset: addHandoutAsset,
-    updateAsset: updateHandoutAsset,
-    deleteAsset: deleteHandoutAsset,
-  } = useHandoutAssets(yDoc)
+  // World store subscriptions
+  const room = useWorldStore((s) => s.room)
+  const scenes = useWorldStore((s) => s.scenes)
+  const entities = useWorldStore((s) => s.entities)
+  const tokens = useWorldStore((s) => s.tokens)
+  const handoutAssets = useWorldStore((s) => s.handoutAssets)
+  const activeScene = useWorldStore(selectActiveScene)
+  const isCombat = useWorldStore(selectIsCombat)
 
-  const [inspectedCharacterId, setInspectedCharacterId] = useState<string | null>(null)
-  const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null)
-  const [bgContextMenu, setBgContextMenu] = useState<{ x: number; y: number } | null>(null)
-  const [editingHandout, setEditingHandout] = useState<HandoutAsset | null>(null)
+  // World store actions
+  const setActiveScene = useWorldStore((s) => s.setActiveScene)
+  const addScene = useWorldStore((s) => s.addScene)
+  const updateScene = useWorldStore((s) => s.updateScene)
+  const deleteSceneRaw = useWorldStore((s) => s.deleteScene)
+  const addEntityToScene = useWorldStore((s) => s.addEntityToScene)
+  const removeEntityFromScene = useWorldStore((s) => s.removeEntityFromScene)
+  const getSceneEntityIds = useWorldStore((s) => s.getSceneEntityIds)
+  const setCombatActive = useWorldStore((s) => s.setCombatActive)
+  const addEntity = useWorldStore((s) => s.addEntity)
+  const updateEntity = useWorldStore((s) => s.updateEntity)
+  const addToken = useWorldStore((s) => s.addToken)
+  const updateToken = useWorldStore((s) => s.updateToken)
+  const deleteToken = useWorldStore((s) => s.deleteToken)
+  const addShowcaseItem = useWorldStore((s) => s.addShowcaseItem)
+  const addHandoutAsset = useWorldStore((s) => s.addHandoutAsset)
+  const updateHandoutAsset = useWorldStore((s) => s.updateHandoutAsset)
+  const deleteHandoutAsset = useWorldStore((s) => s.deleteHandoutAsset)
+  const setActiveTokenScene = useWorldStore((s) => s.setActiveTokenScene)
+
+  // Identity store subscriptions
+  const seats = useIdentityStore((s) => s.seats)
+  const mySeatId = useIdentityStore((s) => s.mySeatId)
+  const onlineSeatIds = useIdentityStore((s) => s.onlineSeatIds)
+  const getMySeat = useIdentityStore((s) => s.getMySeat)
+  const mySeat = getMySeat()
+
+  // Identity store actions
+  const claimSeat = useIdentityStore((s) => s.claimSeat)
+  const createSeat = useIdentityStore((s) => s.createSeat)
+  const deleteSeat = useIdentityStore((s) => s.deleteSeat)
+  const leaveSeat = useIdentityStore((s) => s.leaveSeat)
+  const updateSeat = useIdentityStore((s) => s.updateSeat)
+
+  // UI store
+  const inspectedCharacterId = useUiStore((s) => s.inspectedCharacterId)
+  const selectedTokenId = useUiStore((s) => s.selectedTokenId)
+  const bgContextMenu = useUiStore((s) => s.bgContextMenu)
+  const editingHandout = useUiStore((s) => s.editingHandout)
+  const setInspectedCharacterId = useUiStore((s) => s.setInspectedCharacterId)
+  const setSelectedTokenId = useUiStore((s) => s.setSelectedTokenId)
+  const setBgContextMenu = useUiStore((s) => s.setBgContextMenu)
+  const setEditingHandout = useUiStore((s) => s.setEditingHandout)
+
   // Sync role from seat
   const mySeatRole = mySeat?.role
   useEffect(() => {
     if (mySeatRole) roleStore.set(mySeatRole)
   }, [mySeatRole])
 
+  // Manage token observer based on combat scene
+  const combatSceneId = isCombat ? room.activeSceneId : null
+  useEffect(() => {
+    setActiveTokenScene(combatSceneId)
+  }, [combatSceneId, setActiveTokenScene])
+
   // Auto-set activeCharacterId if seat has an owned entity but no active one
   useEffect(() => {
     if (!mySeat || !mySeatId) return
-    if (mySeat.activeCharacterId) return // already set
+    if (mySeat.activeCharacterId) return
     const ownedEntity = entities.find((e) => e.permissions.seats[mySeatId] === 'owner')
     if (ownedEntity) {
       updateSeat(mySeatId, { activeCharacterId: ownedEntity.id })
@@ -136,42 +163,27 @@ function RoomSession({ roomId }: { roomId: string }) {
   const isGM = mySeat.role === 'GM'
 
   // Derive entity data
+  const getEntity = (id: string | null): Entity | null => {
+    if (!id) return null
+    return entities.find((e) => e.id === id) ?? null
+  }
+
   const activeEntity = getEntity(mySeat.activeCharacterId ?? null)
-  // For selected token in combat
-  const selectedToken = isCombat ? getToken(selectedTokenId) : null
+  const selectedToken = isCombat ? (tokens.find((t) => t.id === selectedTokenId) ?? null) : null
   const selectedTokenEntity = selectedToken?.entityId ? getEntity(selectedToken.entityId) : null
 
-  // Flatten resources + attributes into { key, value }[] for chat @key autocomplete
-  const allProps = [
-    ...getEntityResources(activeEntity)
-      .filter((r) => r.key)
-      .map((r) => ({ key: r.key, value: String(r.current) })),
-    ...getEntityAttributes(activeEntity)
-      .filter((a) => a.key)
-      .map((a) => ({ key: a.key, value: String(a.value) })),
-    ...getEntityResources(selectedTokenEntity)
-      .filter((r) => r.key)
-      .map((r) => ({ key: r.key, value: String(r.current) })),
-    ...getEntityAttributes(selectedTokenEntity)
-      .filter((a) => a.key)
-      .map((a) => ({ key: a.key, value: String(a.value) })),
-  ]
-  // Deduplicate by key — later entries (token entity) override earlier (active entity)
-  const seatProperties = [...new Map(allProps.map((p) => [p.key, p])).values()]
+  const seatProperties = deriveSeatProperties(activeEntity, selectedTokenEntity)
 
-  // Derive current scene's entity IDs for PortraitBar filtering
   const sceneEntityIds = room.activeSceneId ? getSceneEntityIds(room.activeSceneId) : []
 
-  // Handle removing an entity from the current scene (without deleting it)
   const handleRemoveFromScene = (entityId: string) => {
     if (room.activeSceneId) removeEntityFromScene(room.activeSceneId, entityId)
     if (inspectedCharacterId === entityId) setInspectedCharacterId(null)
   }
 
-  // Delete scene + garbage-collect orphaned non-persistent entities
   const handleDeleteScene = (sceneId: string) => {
     const entityIds = getSceneEntityIds(sceneId)
-    deleteScene(sceneId)
+    deleteSceneRaw(sceneId)
     yDoc.transact(() => {
       const deleted = gcOrphanedEntities(entityIds, world.scenes, world.entities)
       if (deleted.length > 0 && inspectedCharacterId && deleted.includes(inspectedCharacterId)) {
@@ -180,13 +192,11 @@ function RoomSession({ roomId }: { roomId: string }) {
     })
   }
 
-  // Add scene with persistent entities auto-joined
   const handleAddScene = (scene: Scene) => {
     const persistentIds = getPersistentEntityIds(world.entities)
     addScene(scene, persistentIds)
   }
 
-  // Add entity — if persistent, auto-join all existing scenes
   const handleAddEntity = (entity: Entity) => {
     addEntity(entity)
     if (entity.persistent) {
@@ -194,7 +204,6 @@ function RoomSession({ roomId }: { roomId: string }) {
     }
   }
 
-  // Update entity — if persistent toggled to true, auto-join all scenes
   const handleUpdateEntity = (id: string, updates: Partial<Entity>) => {
     if (updates.persistent === true) {
       const existing = getEntity(id)
@@ -205,7 +214,6 @@ function RoomSession({ roomId }: { roomId: string }) {
     updateEntity(id, updates)
   }
 
-  // Handle setting active character
   const handleSetActiveCharacter = (entityId: string) => {
     if (mySeatId) {
       updateSeat(mySeatId, { activeCharacterId: entityId })
@@ -308,9 +316,7 @@ function RoomSession({ roomId }: { roomId: string }) {
         senderColor={mySeat.color}
         portraitUrl={mySeat.portraitUrl || activeEntity?.imageUrl}
         seatProperties={seatProperties}
-        speakerEntities={
-          isGM ? entities : entities.filter((e) => e.permissions.seats[mySeatId] === 'owner')
-        }
+        speakerEntities={selectSpeakerEntities(entities, mySeatId, isGM)}
       />
 
       {/* Bottom dock: asset library (maps + tokens) — visible in both modes for GM */}
@@ -328,7 +334,7 @@ function RoomSession({ roomId }: { roomId: string }) {
             if (room.activeSceneId) addEntityToScene(room.activeSceneId, entityId)
           }}
           isCombat={isCombat}
-          selectedToken={getToken(selectedTokenId)}
+          selectedToken={selectedToken}
           onAddToken={addToken}
           onDeleteToken={deleteToken}
           onUpdateToken={updateToken}

--- a/src/stores/identityStore.ts
+++ b/src/stores/identityStore.ts
@@ -1,0 +1,164 @@
+// src/stores/identityStore.ts
+// Identity store: seats, mySeat, awareness, online tracking.
+// Yjs observer on seats map writes into the store.
+// Awareness broadcasts are managed here.
+
+import { create } from 'zustand'
+import * as Y from 'yjs'
+import type { Awareness } from 'y-protocols/awareness'
+
+export interface Seat {
+  id: string
+  name: string
+  color: string
+  role: 'GM' | 'PL'
+  portraitUrl?: string
+  activeCharacterId?: string
+}
+
+const SEAT_STORAGE_KEY = 'myvtt-seat-id'
+
+export const SEAT_COLORS = [
+  '#3b82f6',
+  '#ef4444',
+  '#10b981',
+  '#f59e0b',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#f97316',
+]
+
+interface IdentityState {
+  seats: Seat[]
+  mySeatId: string | null
+  onlineSeatIds: Set<string>
+
+  // Yjs refs (set during init)
+  _ySeats: Y.Map<Seat> | null
+  _awareness: Awareness | null
+
+  // Derived getter
+  getMySeat: () => Seat | null
+
+  // Init — connects Yjs observer + awareness listener
+  init: (ySeats: Y.Map<unknown>, awareness: Awareness | null) => () => void
+
+  // Actions
+  claimSeat: (seatId: string) => void
+  createSeat: (name: string, role: 'GM' | 'PL', color?: string) => string
+  leaveSeat: () => void
+  deleteSeat: (seatId: string) => void
+  updateSeat: (seatId: string, updates: Partial<Omit<Seat, 'id'>>) => void
+}
+
+export const useIdentityStore = create<IdentityState>((set, get) => ({
+  seats: [],
+  mySeatId: null,
+  onlineSeatIds: new Set(),
+
+  _ySeats: null,
+  _awareness: null,
+
+  getMySeat: () => {
+    const { mySeatId, _ySeats } = get()
+    if (!mySeatId || !_ySeats) return null
+    return _ySeats.get(mySeatId) ?? null
+  },
+
+  init: (ySeats: Y.Map<unknown>, awareness: Awareness | null) => {
+    const yPlayers = ySeats as Y.Map<Seat>
+    set({ _ySeats: yPlayers, _awareness: awareness })
+
+    // Seats observer
+    const updateSeats = () => {
+      const allSeats: Seat[] = []
+      yPlayers.forEach((seat) => allSeats.push(seat))
+      set({ seats: allSeats })
+
+      // Auto-claim from sessionStorage on initial sync
+      const { mySeatId } = get()
+      if (!mySeatId) {
+        const cached = sessionStorage.getItem(SEAT_STORAGE_KEY)
+        if (cached && yPlayers.has(cached)) {
+          set({ mySeatId: cached })
+        }
+      }
+    }
+    updateSeats()
+    yPlayers.observe(updateSeats)
+
+    // Awareness observer for online tracking
+    let awarenessCleanup: (() => void) | undefined
+    if (awareness) {
+      const updateOnline = () => {
+        const online = new Set<string>()
+        awareness.getStates().forEach((state, clientId) => {
+          if (clientId === awareness.clientID) return
+          if (state.seat?.seatId) online.add(state.seat.seatId)
+        })
+        set({ onlineSeatIds: online })
+      }
+      updateOnline()
+      awareness.on('change', updateOnline)
+      awarenessCleanup = () => awareness.off('change', updateOnline)
+    }
+
+    return () => {
+      yPlayers.unobserve(updateSeats)
+      awarenessCleanup?.()
+    }
+  },
+
+  claimSeat: (seatId: string) => {
+    set({ mySeatId: seatId })
+    sessionStorage.setItem(SEAT_STORAGE_KEY, seatId)
+
+    // Broadcast via awareness
+    const { _awareness: awareness, _ySeats: yPlayers } = get()
+    if (awareness && yPlayers) {
+      const seat = yPlayers.get(seatId)
+      if (seat) {
+        awareness.setLocalStateField('seat', {
+          seatId: seat.id,
+          name: seat.name,
+          color: seat.color,
+        })
+      }
+    }
+  },
+
+  createSeat: (name: string, role: 'GM' | 'PL', color?: string) => {
+    const { _ySeats: yPlayers, seats, claimSeat } = get()
+    if (!yPlayers) return ''
+    const id =
+      self.crypto?.randomUUID?.() ??
+      Math.random().toString(36).slice(2) + Date.now().toString(36)
+    const seatColor = color ?? SEAT_COLORS[seats.length % SEAT_COLORS.length]
+    const seat: Seat = { id, name, color: seatColor, role }
+    yPlayers.set(id, seat)
+    claimSeat(id)
+    return id
+  },
+
+  leaveSeat: () => {
+    set({ mySeatId: null })
+    sessionStorage.removeItem(SEAT_STORAGE_KEY)
+    const { _awareness: awareness } = get()
+    if (awareness) {
+      awareness.setLocalStateField('seat', null)
+    }
+  },
+
+  deleteSeat: (seatId: string) => {
+    get()._ySeats?.delete(seatId)
+  },
+
+  updateSeat: (seatId: string, updates: Partial<Omit<Seat, 'id'>>) => {
+    const yPlayers = get()._ySeats
+    if (!yPlayers) return
+    const seat = yPlayers.get(seatId)
+    if (!seat) return
+    yPlayers.set(seatId, { ...seat, ...updates })
+  },
+}))

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -1,0 +1,85 @@
+// src/stores/selectors.ts
+// Reusable selectors for derived data from stores.
+// Components use these with useWorldStore(selector) for fine-grained subscriptions.
+
+import type { Entity, MapToken } from '../shared/entityTypes'
+import type { Scene, RoomState } from './worldStore'
+import type { Seat } from './identityStore'
+import { getEntityResources, getEntityAttributes } from '../shared/entityAdapters'
+
+// ── World store selectors ──
+
+export const selectRoom = (s: { room: RoomState }) => s.room
+export const selectActiveSceneId = (s: { room: RoomState }) => s.room.activeSceneId
+export const selectScenes = (s: { scenes: Scene[] }) => s.scenes
+export const selectEntities = (s: { entities: Entity[] }) => s.entities
+export const selectTokens = (s: { tokens: MapToken[] }) => s.tokens
+export const selectBlueprints = (s: { blueprints: unknown[] }) => s.blueprints
+
+export const selectActiveScene = (s: { room: RoomState; scenes: Scene[] }): Scene | null => {
+  const id = s.room.activeSceneId
+  if (!id) return null
+  return s.scenes.find((sc) => sc.id === id) ?? null
+}
+
+export const selectIsCombat = (s: { room: RoomState; scenes: Scene[] }): boolean => {
+  const scene = selectActiveScene(s)
+  return scene?.combatActive ?? false
+}
+
+// ── Entity lookups ──
+
+export function selectEntityById(id: string | null) {
+  return (s: { entities: Entity[] }): Entity | null => {
+    if (!id) return null
+    return s.entities.find((e) => e.id === id) ?? null
+  }
+}
+
+export function selectTokenById(id: string | null) {
+  return (s: { tokens: MapToken[] }): MapToken | null => {
+    if (!id) return null
+    return s.tokens.find((t) => t.id === id) ?? null
+  }
+}
+
+// ── Derived chat properties ──
+
+export function deriveSeatProperties(
+  activeEntity: Entity | null,
+  selectedTokenEntity: Entity | null,
+): { key: string; value: string }[] {
+  const allProps = [
+    ...getEntityResources(activeEntity)
+      .filter((r) => r.key)
+      .map((r) => ({ key: r.key, value: String(r.current) })),
+    ...getEntityAttributes(activeEntity)
+      .filter((a) => a.key)
+      .map((a) => ({ key: a.key, value: String(a.value) })),
+    ...getEntityResources(selectedTokenEntity)
+      .filter((r) => r.key)
+      .map((r) => ({ key: r.key, value: String(r.current) })),
+    ...getEntityAttributes(selectedTokenEntity)
+      .filter((a) => a.key)
+      .map((a) => ({ key: a.key, value: String(a.value) })),
+  ]
+  return [...new Map(allProps.map((p) => [p.key, p])).values()]
+}
+
+// ── Speaker entities (for chat) ──
+
+export function selectSpeakerEntities(
+  entities: Entity[],
+  mySeatId: string | null,
+  isGM: boolean,
+): Entity[] {
+  if (isGM) return entities
+  if (!mySeatId) return []
+  return entities.filter((e) => e.permissions.seats[mySeatId] === 'owner')
+}
+
+// ── Identity selectors ──
+
+export const selectSeats = (s: { seats: Seat[] }) => s.seats
+export const selectMySeatId = (s: { mySeatId: string | null }) => s.mySeatId
+export const selectOnlineSeatIds = (s: { onlineSeatIds: Set<string> }) => s.onlineSeatIds

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,0 +1,34 @@
+// src/stores/uiStore.ts
+// Client-only UI state. No Yjs observers needed — purely local.
+
+import { create } from 'zustand'
+import type { HandoutAsset } from './worldStore'
+
+interface ContextMenuState {
+  x: number
+  y: number
+}
+
+interface UiState {
+  inspectedCharacterId: string | null
+  selectedTokenId: string | null
+  bgContextMenu: ContextMenuState | null
+  editingHandout: HandoutAsset | null
+
+  setInspectedCharacterId: (id: string | null) => void
+  setSelectedTokenId: (id: string | null) => void
+  setBgContextMenu: (menu: ContextMenuState | null) => void
+  setEditingHandout: (asset: HandoutAsset | null) => void
+}
+
+export const useUiStore = create<UiState>((set) => ({
+  inspectedCharacterId: null,
+  selectedTokenId: null,
+  bgContextMenu: null,
+  editingHandout: null,
+
+  setInspectedCharacterId: (id) => set({ inspectedCharacterId: id }),
+  setSelectedTokenId: (id) => set({ selectedTokenId: id }),
+  setBgContextMenu: (menu) => set({ bgContextMenu: menu }),
+  setEditingHandout: (asset) => set({ editingHandout: asset }),
+}))

--- a/src/stores/worldStore.ts
+++ b/src/stores/worldStore.ts
@@ -1,0 +1,704 @@
+// src/stores/worldStore.ts
+// Central zustand store that bridges Yjs data to React.
+// Yjs observers write data into this store; components read via selectors.
+// Write operations go directly to Yjs — the observer callback updates the store.
+
+import { create } from 'zustand'
+import * as Y from 'yjs'
+import type { Entity, EntityPermissions, MapToken, Blueprint } from '../shared/entityTypes'
+import type { ShowcaseItem } from '../showcase/showcaseTypes'
+
+// ── Types ──
+
+export interface Scene {
+  id: string
+  name: string
+  imageUrl: string
+  width: number
+  height: number
+  gridSize: number
+  gridVisible: boolean
+  gridColor: string
+  gridOffsetX: number
+  gridOffsetY: number
+  sortOrder: number
+  combatActive: boolean
+  battleMapUrl: string
+}
+
+export interface RoomState {
+  activeSceneId: string | null
+}
+
+export interface HandoutAsset {
+  id: string
+  imageUrl: string
+  title?: string
+  description?: string
+  createdAt: number
+}
+
+export interface TeamTracker {
+  id: string
+  label: string
+  current: number
+  max: number
+  color: string
+  sortOrder: number
+}
+
+// ── Read helpers (Yjs → plain objects) ──
+
+function readPermissions(yMap: Y.Map<unknown>): EntityPermissions {
+  const permYMap = yMap.get('permissions')
+  if (permYMap instanceof Y.Map) {
+    const seatsYMap = permYMap.get('seats')
+    const seats: Record<string, EntityPermissions['seats'][string]> = {}
+    if (seatsYMap instanceof Y.Map) {
+      seatsYMap.forEach((val, key) => {
+        seats[key] = val as EntityPermissions['seats'][string]
+      })
+    }
+    return {
+      default: (permYMap.get('default') as EntityPermissions['default']) ?? 'observer',
+      seats,
+    }
+  }
+  return { default: 'observer', seats: {} }
+}
+
+function readRuleData(yMap: Y.Map<unknown>): unknown {
+  const ruleYMap = yMap.get('ruleData')
+  if (ruleYMap instanceof Y.Map) {
+    if (ruleYMap.size === 0) return null
+    const obj: Record<string, unknown> = {}
+    ruleYMap.forEach((val, key) => {
+      obj[key] = val
+    })
+    return obj
+  }
+  return null
+}
+
+function readYMapEntity(yMap: Y.Map<unknown>): Entity {
+  return {
+    id: yMap.get('id') as string,
+    name: (yMap.get('name') as string) ?? '',
+    imageUrl: (yMap.get('imageUrl') as string) ?? '',
+    color: (yMap.get('color') as string) ?? '',
+    size: (yMap.get('size') as number) ?? 1,
+    blueprintId: yMap.get('blueprintId') as string | undefined,
+    notes: (yMap.get('notes') as string) ?? '',
+    ruleData: readRuleData(yMap),
+    permissions: readPermissions(yMap),
+    persistent: (yMap.get('persistent') as boolean) ?? false,
+  }
+}
+
+function readScenes(yScenes: Y.Map<Y.Map<unknown>>): Scene[] {
+  const scenes: Scene[] = []
+  yScenes.forEach((sceneMap, id) => {
+    if (!(sceneMap instanceof Y.Map)) return
+    scenes.push({
+      id,
+      name: (sceneMap.get('name') as string) ?? '',
+      imageUrl: (sceneMap.get('imageUrl') as string) ?? '',
+      width: (sceneMap.get('width') as number) ?? 0,
+      height: (sceneMap.get('height') as number) ?? 0,
+      gridSize: (sceneMap.get('gridSize') as number) ?? 50,
+      gridVisible: (sceneMap.get('gridVisible') as boolean) ?? true,
+      gridColor: (sceneMap.get('gridColor') as string) ?? 'rgba(255,255,255,0.15)',
+      gridOffsetX: (sceneMap.get('gridOffsetX') as number) ?? 0,
+      gridOffsetY: (sceneMap.get('gridOffsetY') as number) ?? 0,
+      sortOrder: (sceneMap.get('sortOrder') as number) ?? 0,
+      combatActive: (sceneMap.get('combatActive') as boolean) ?? false,
+      battleMapUrl: (sceneMap.get('battleMapUrl') as string) ?? '',
+    })
+  })
+  scenes.sort((a, b) => a.sortOrder - b.sortOrder)
+  return scenes
+}
+
+function readEntities(yEntities: Y.Map<Y.Map<unknown>>): Entity[] {
+  const result: Entity[] = []
+  yEntities.forEach((yMap) => {
+    if (yMap instanceof Y.Map) {
+      result.push(readYMapEntity(yMap))
+    }
+  })
+  return result
+}
+
+function readTokens(tokensMap: Y.Map<MapToken> | null): MapToken[] {
+  if (!tokensMap) return []
+  const result: MapToken[] = []
+  tokensMap.forEach((t) => result.push(t))
+  return result
+}
+
+function readRoom(yRoom: Y.Map<unknown>): RoomState {
+  return {
+    activeSceneId: (yRoom.get('activeSceneId') as string) ?? null,
+  }
+}
+
+function readShowcaseItems(yShowcase: Y.Map<ShowcaseItem>): ShowcaseItem[] {
+  const items: ShowcaseItem[] = []
+  yShowcase.forEach((item) => items.push(item))
+  items.sort((a, b) => a.timestamp - b.timestamp)
+  return items
+}
+
+function readHandoutAssets(yHandouts: Y.Map<HandoutAsset>): HandoutAsset[] {
+  const items: HandoutAsset[] = []
+  yHandouts.forEach((item) => items.push(item))
+  items.sort((a, b) => a.createdAt - b.createdAt)
+  return items
+}
+
+function readBlueprints(yBlueprints: Y.Map<unknown>): Blueprint[] {
+  const items: Blueprint[] = []
+  yBlueprints.forEach((item) => {
+    if (item && typeof item === 'object') items.push(item as Blueprint)
+  })
+  return items
+}
+
+function readTeamTrackers(yMetrics: Y.Map<TeamTracker>): TeamTracker[] {
+  const items: TeamTracker[] = []
+  yMetrics.forEach((item) => items.push(item))
+  items.sort((a, b) => a.sortOrder - b.sortOrder)
+  return items
+}
+
+// ── Write helpers (write to Yjs) ──
+
+function writePermissions(entityYMap: Y.Map<unknown>, permissions: EntityPermissions) {
+  const permYMap = new Y.Map<unknown>()
+  entityYMap.set('permissions', permYMap)
+  permYMap.set('default', permissions.default)
+  const seatsYMap = new Y.Map<unknown>()
+  permYMap.set('seats', seatsYMap)
+  for (const [seatId, level] of Object.entries(permissions.seats)) {
+    seatsYMap.set(seatId, level)
+  }
+}
+
+function writeRuleData(entityYMap: Y.Map<unknown>, ruleData: unknown) {
+  const ruleYMap = new Y.Map<unknown>()
+  entityYMap.set('ruleData', ruleYMap)
+  if (ruleData && typeof ruleData === 'object') {
+    for (const [key, value] of Object.entries(ruleData as Record<string, unknown>)) {
+      ruleYMap.set(key, value)
+    }
+  }
+}
+
+function setYMapFields(yMap: Y.Map<unknown>, entity: Entity) {
+  yMap.set('id', entity.id)
+  yMap.set('name', entity.name)
+  yMap.set('imageUrl', entity.imageUrl)
+  yMap.set('color', entity.color)
+  yMap.set('size', entity.size)
+  if (entity.blueprintId) yMap.set('blueprintId', entity.blueprintId)
+  yMap.set('notes', entity.notes)
+  yMap.set('persistent', entity.persistent)
+  writeRuleData(yMap, entity.ruleData)
+  writePermissions(yMap, entity.permissions)
+}
+
+function updatePermissionsInPlace(entityYMap: Y.Map<unknown>, permissions: EntityPermissions) {
+  const permYMap = entityYMap.get('permissions')
+  if (permYMap instanceof Y.Map) {
+    permYMap.set('default', permissions.default)
+    const seatsYMap = permYMap.get('seats')
+    if (seatsYMap instanceof Y.Map) {
+      const newSeatIds = new Set(Object.keys(permissions.seats))
+      seatsYMap.forEach((_v, k) => {
+        if (!newSeatIds.has(k)) seatsYMap.delete(k)
+      })
+      for (const [seatId, level] of Object.entries(permissions.seats)) {
+        seatsYMap.set(seatId, level)
+      }
+    }
+  } else {
+    writePermissions(entityYMap, permissions)
+  }
+}
+
+function updateRuleDataInPlace(entityYMap: Y.Map<unknown>, ruleData: unknown) {
+  const ruleYMap = entityYMap.get('ruleData')
+  if (ruleYMap instanceof Y.Map) {
+    if (ruleData && typeof ruleData === 'object') {
+      for (const [key, value] of Object.entries(ruleData as Record<string, unknown>)) {
+        ruleYMap.set(key, value)
+      }
+    }
+  } else {
+    writeRuleData(entityYMap, ruleData)
+  }
+}
+
+function getTokensMap(
+  yScenes: Y.Map<Y.Map<unknown>>,
+  sceneId: string | null,
+): Y.Map<MapToken> | null {
+  if (!sceneId) return null
+  const sceneMap = yScenes.get(sceneId)
+  if (!(sceneMap instanceof Y.Map)) return null
+  const tokens = sceneMap.get('tokens')
+  if (tokens instanceof Y.Map) return tokens as Y.Map<MapToken>
+  return null
+}
+
+// ── Store interface ──
+
+interface WorldState {
+  // Data slices
+  room: RoomState
+  scenes: Scene[]
+  entities: Entity[]
+  tokens: MapToken[]
+  showcaseItems: ShowcaseItem[]
+  showcasePinnedItemId: string | null
+  handoutAssets: HandoutAsset[]
+  blueprints: Blueprint[]
+  teamTrackers: TeamTracker[]
+
+  // Yjs refs (not serializable — set once during init, used by actions)
+  _yDoc: Y.Doc | null
+  _yScenes: Y.Map<Y.Map<unknown>> | null
+  _yEntities: Y.Map<Y.Map<unknown>> | null
+  _yRoom: Y.Map<unknown> | null
+  _yBlueprints: Y.Map<unknown> | null
+  _yShowcase: Y.Map<ShowcaseItem> | null
+  _yHandouts: Y.Map<HandoutAsset> | null
+  _yMetrics: Y.Map<TeamTracker> | null
+  _activeTokenSceneId: string | null
+
+  // Initialization — connects Yjs observers to store
+  init: (yDoc: Y.Doc) => () => void
+
+  // Room actions
+  setActiveScene: (sceneId: string) => void
+
+  // Scene actions
+  addScene: (scene: Scene, persistentEntityIds?: string[]) => void
+  updateScene: (id: string, updates: Partial<Scene>) => void
+  deleteScene: (id: string) => void
+  getScene: (id: string | null) => Scene | null
+  addEntityToScene: (sceneId: string, entityId: string) => void
+  removeEntityFromScene: (sceneId: string, entityId: string) => void
+  getSceneEntityIds: (sceneId: string) => string[]
+  setCombatActive: (sceneId: string, active: boolean) => void
+
+  // Entity actions
+  addEntity: (entity: Entity) => void
+  updateEntity: (id: string, updates: Partial<Entity>) => void
+  deleteEntity: (id: string) => void
+
+  // Token actions
+  setActiveTokenScene: (sceneId: string | null) => void
+  addToken: (token: MapToken) => void
+  updateToken: (id: string, updates: Partial<MapToken>) => void
+  deleteToken: (id: string) => void
+
+  // Showcase actions
+  addShowcaseItem: (item: ShowcaseItem) => void
+  updateShowcaseItem: (id: string, updates: Partial<ShowcaseItem>) => void
+  deleteShowcaseItem: (id: string) => void
+  clearShowcase: () => void
+  pinShowcaseItem: (id: string) => void
+  unpinShowcaseItem: () => void
+
+  // Handout actions
+  addHandoutAsset: (asset: HandoutAsset) => void
+  updateHandoutAsset: (id: string, updates: Partial<HandoutAsset>) => void
+  deleteHandoutAsset: (id: string) => void
+
+  // Blueprint actions (read-only via observer, write via Yjs directly)
+
+  // Team metrics actions
+  addTeamTracker: (label: string) => void
+  updateTeamTracker: (id: string, updates: Partial<TeamTracker>) => void
+  deleteTeamTracker: (id: string) => void
+}
+
+const DEFAULT_TRACKER_COLORS = [
+  '#ef4444',
+  '#22c55e',
+  '#3b82f6',
+  '#f59e0b',
+  '#a855f7',
+  '#ec4899',
+]
+
+export const useWorldStore = create<WorldState>((set, get) => ({
+  // Initial data
+  room: { activeSceneId: null },
+  scenes: [],
+  entities: [],
+  tokens: [],
+  showcaseItems: [],
+  showcasePinnedItemId: null,
+  handoutAssets: [],
+  blueprints: [],
+  teamTrackers: [],
+
+  // Yjs refs
+  _yDoc: null,
+  _yScenes: null,
+  _yEntities: null,
+  _yRoom: null,
+  _yBlueprints: null,
+  _yShowcase: null,
+  _yHandouts: null,
+  _yMetrics: null,
+  _activeTokenSceneId: null,
+
+  // ── Init: wire Yjs observers to store ──
+  init: (yDoc: Y.Doc) => {
+    const yScenes = yDoc.getMap('scenes') as Y.Map<Y.Map<unknown>>
+    const yEntities = yDoc.getMap('entities') as Y.Map<Y.Map<unknown>>
+    const yRoom = yDoc.getMap('room')
+    const yBlueprints = yDoc.getMap('blueprints')
+    const yShowcase = yDoc.getMap<ShowcaseItem>('showcase_items')
+    const yHandouts = yDoc.getMap<HandoutAsset>('handout_assets')
+    const yMetrics = yDoc.getMap<TeamTracker>('team_metrics')
+
+    // Store refs for actions
+    set({
+      _yDoc: yDoc,
+      _yScenes: yScenes,
+      _yEntities: yEntities,
+      _yRoom: yRoom,
+      _yBlueprints: yBlueprints,
+      _yShowcase: yShowcase,
+      _yHandouts: yHandouts,
+      _yMetrics: yMetrics,
+    })
+
+    // Initial reads
+    set({
+      room: readRoom(yRoom),
+      scenes: readScenes(yScenes),
+      entities: readEntities(yEntities),
+      showcaseItems: readShowcaseItems(yShowcase),
+      showcasePinnedItemId: (yRoom.get('pinnedShowcaseId') as string) ?? null,
+      handoutAssets: readHandoutAssets(yHandouts),
+      blueprints: readBlueprints(yBlueprints),
+      teamTrackers: readTeamTrackers(yMetrics),
+    })
+
+    // Observers
+    const roomObserver = () => {
+      set({
+        room: readRoom(yRoom),
+        showcasePinnedItemId: (yRoom.get('pinnedShowcaseId') as string) ?? null,
+      })
+    }
+    const scenesObserver = () => set({ scenes: readScenes(yScenes) })
+    const entitiesObserver = () => set({ entities: readEntities(yEntities) })
+    const showcaseObserver = () => set({ showcaseItems: readShowcaseItems(yShowcase) })
+    const handoutsObserver = () => set({ handoutAssets: readHandoutAssets(yHandouts) })
+    const blueprintsObserver = () => set({ blueprints: readBlueprints(yBlueprints) })
+    const metricsObserver = () => set({ teamTrackers: readTeamTrackers(yMetrics) })
+
+    yRoom.observe(roomObserver)
+    yScenes.observeDeep(scenesObserver)
+    yEntities.observeDeep(entitiesObserver)
+    yShowcase.observe(showcaseObserver)
+    yHandouts.observe(handoutsObserver)
+    yBlueprints.observe(blueprintsObserver)
+    yMetrics.observe(metricsObserver)
+
+    // Token observer management
+    let tokenCleanup: (() => void) | null = null
+    const setupTokenObserver = (sceneId: string | null) => {
+      tokenCleanup?.()
+      tokenCleanup = null
+      const tokensMap = getTokensMap(yScenes, sceneId)
+      if (!tokensMap) {
+        set({ tokens: [] })
+        return
+      }
+      const tokenObserver = () => set({ tokens: readTokens(tokensMap) })
+      set({ tokens: readTokens(tokensMap) })
+      tokensMap.observe(tokenObserver)
+      tokenCleanup = () => tokensMap.unobserve(tokenObserver)
+    }
+
+    // Store the setup function for dynamic scene changes
+    const origSetActiveTokenScene = get().setActiveTokenScene
+    set({
+      setActiveTokenScene: (sceneId: string | null) => {
+        set({ _activeTokenSceneId: sceneId })
+        setupTokenObserver(sceneId)
+      },
+    })
+    // If there's already an active token scene, set it up
+    const currentTokenScene = get()._activeTokenSceneId
+    if (currentTokenScene) setupTokenObserver(currentTokenScene)
+
+    // Cleanup function
+    return () => {
+      yRoom.unobserve(roomObserver)
+      yScenes.unobserveDeep(scenesObserver)
+      yEntities.unobserveDeep(entitiesObserver)
+      yShowcase.unobserve(showcaseObserver)
+      yHandouts.unobserve(handoutsObserver)
+      yBlueprints.unobserve(blueprintsObserver)
+      yMetrics.unobserve(metricsObserver)
+      tokenCleanup?.()
+      // Restore no-op token scene setter
+      set({ setActiveTokenScene: origSetActiveTokenScene })
+    }
+  },
+
+  // ── Room actions ──
+  setActiveScene: (sceneId: string) => {
+    get()._yRoom?.set('activeSceneId', sceneId)
+  },
+
+  // ── Scene actions ──
+  addScene: (scene: Scene, persistentEntityIds?: string[]) => {
+    const { _yScenes: yScenes, _yDoc: yDoc } = get()
+    if (!yScenes || !yDoc) return
+    yDoc.transact(() => {
+      const sceneMap = new Y.Map<unknown>()
+      yScenes.set(scene.id, sceneMap)
+      sceneMap.set('name', scene.name)
+      sceneMap.set('imageUrl', scene.imageUrl)
+      sceneMap.set('width', scene.width)
+      sceneMap.set('height', scene.height)
+      sceneMap.set('gridSize', scene.gridSize)
+      sceneMap.set('gridVisible', scene.gridVisible)
+      sceneMap.set('gridColor', scene.gridColor)
+      sceneMap.set('gridOffsetX', scene.gridOffsetX)
+      sceneMap.set('gridOffsetY', scene.gridOffsetY)
+      sceneMap.set('sortOrder', scene.sortOrder)
+      sceneMap.set('combatActive', false)
+      sceneMap.set('battleMapUrl', '')
+      const entityIdsMap = new Y.Map<boolean>()
+      sceneMap.set('entityIds', entityIdsMap)
+      if (persistentEntityIds) {
+        for (const eid of persistentEntityIds) {
+          entityIdsMap.set(eid, true)
+        }
+      }
+      sceneMap.set('tokens', new Y.Map())
+    })
+  },
+
+  updateScene: (id: string, updates: Partial<Scene>) => {
+    const { _yScenes: yScenes, _yDoc: yDoc } = get()
+    if (!yScenes || !yDoc) return
+    const sceneMap = yScenes.get(id)
+    if (!(sceneMap instanceof Y.Map)) return
+    yDoc.transact(() => {
+      for (const [key, value] of Object.entries(updates)) {
+        if (key === 'id') continue
+        sceneMap.set(key, value)
+      }
+    })
+  },
+
+  deleteScene: (id: string) => {
+    get()._yScenes?.delete(id)
+  },
+
+  getScene: (id: string | null): Scene | null => {
+    if (!id) return null
+    return get().scenes.find((s) => s.id === id) ?? null
+  },
+
+  addEntityToScene: (sceneId: string, entityId: string) => {
+    const yScenes = get()._yScenes
+    if (!yScenes) return
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    const entityIds = sceneMap.get('entityIds')
+    if (entityIds instanceof Y.Map) {
+      entityIds.set(entityId, true)
+    }
+  },
+
+  removeEntityFromScene: (sceneId: string, entityId: string) => {
+    const yScenes = get()._yScenes
+    if (!yScenes) return
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    const entityIds = sceneMap.get('entityIds')
+    if (entityIds instanceof Y.Map) {
+      entityIds.delete(entityId)
+    }
+  },
+
+  getSceneEntityIds: (sceneId: string): string[] => {
+    const yScenes = get()._yScenes
+    if (!yScenes) return []
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return []
+    const entityIds = sceneMap.get('entityIds')
+    if (!(entityIds instanceof Y.Map)) return []
+    const ids: string[] = []
+    entityIds.forEach((_val, key) => ids.push(key))
+    return ids
+  },
+
+  setCombatActive: (sceneId: string, active: boolean) => {
+    const yScenes = get()._yScenes
+    if (!yScenes) return
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    sceneMap.set('combatActive', active)
+  },
+
+  // ── Entity actions ──
+  addEntity: (entity: Entity) => {
+    const { _yEntities: yEntities, _yDoc: yDoc } = get()
+    if (!yEntities || !yDoc) return
+    yDoc.transact(() => {
+      const yMap = new Y.Map<unknown>()
+      yEntities.set(entity.id, yMap)
+      setYMapFields(yMap, entity)
+    })
+  },
+
+  updateEntity: (id: string, updates: Partial<Entity>) => {
+    const { _yEntities: yEntities, _yDoc: yDoc } = get()
+    if (!yEntities || !yDoc) return
+    const entityYMap = yEntities.get(id)
+    if (!(entityYMap instanceof Y.Map)) return
+    yDoc.transact(() => {
+      for (const [key, value] of Object.entries(updates)) {
+        if (key === 'permissions') {
+          updatePermissionsInPlace(entityYMap, value as EntityPermissions)
+        } else if (key === 'ruleData') {
+          updateRuleDataInPlace(entityYMap, value)
+        } else {
+          entityYMap.set(key, value)
+        }
+      }
+    })
+  },
+
+  deleteEntity: (id: string) => {
+    get()._yEntities?.delete(id)
+  },
+
+  // ── Token actions ──
+  setActiveTokenScene: (sceneId: string | null) => {
+    // No-op before init; init() replaces this with the real implementation
+    set({ _activeTokenSceneId: sceneId, tokens: [] })
+  },
+
+  addToken: (token: MapToken) => {
+    const tokensMap = getTokensMap(get()._yScenes!, get()._activeTokenSceneId)
+    tokensMap?.set(token.id, token)
+  },
+
+  updateToken: (id: string, updates: Partial<MapToken>) => {
+    const tokensMap = getTokensMap(get()._yScenes!, get()._activeTokenSceneId)
+    if (!tokensMap) return
+    const existing = tokensMap.get(id)
+    if (existing) {
+      tokensMap.set(id, { ...existing, ...updates })
+    }
+  },
+
+  deleteToken: (id: string) => {
+    const tokensMap = getTokensMap(get()._yScenes!, get()._activeTokenSceneId)
+    tokensMap?.delete(id)
+  },
+
+  // ── Showcase actions ──
+  addShowcaseItem: (item: ShowcaseItem) => {
+    get()._yShowcase?.set(item.id, item)
+  },
+
+  updateShowcaseItem: (id: string, updates: Partial<ShowcaseItem>) => {
+    const yShowcase = get()._yShowcase
+    if (!yShowcase) return
+    const existing = yShowcase.get(id)
+    if (existing) {
+      yShowcase.set(id, { ...existing, ...updates })
+    }
+  },
+
+  deleteShowcaseItem: (id: string) => {
+    const yShowcase = get()._yShowcase
+    const yRoom = get()._yRoom
+    yShowcase?.delete(id)
+    if ((yRoom?.get('pinnedShowcaseId') as string) === id) {
+      yRoom?.delete('pinnedShowcaseId')
+    }
+  },
+
+  clearShowcase: () => {
+    const { _yShowcase: yShowcase, _yRoom: yRoom, _yDoc: yDoc } = get()
+    if (!yShowcase || !yRoom || !yDoc) return
+    yDoc.transact(() => {
+      yShowcase.forEach((_val, key) => yShowcase.delete(key))
+      yRoom.delete('pinnedShowcaseId')
+    })
+  },
+
+  pinShowcaseItem: (id: string) => {
+    get()._yRoom?.set('pinnedShowcaseId', id)
+  },
+
+  unpinShowcaseItem: () => {
+    get()._yRoom?.delete('pinnedShowcaseId')
+  },
+
+  // ── Handout actions ──
+  addHandoutAsset: (asset: HandoutAsset) => {
+    get()._yHandouts?.set(asset.id, asset)
+  },
+
+  updateHandoutAsset: (id: string, updates: Partial<HandoutAsset>) => {
+    const yHandouts = get()._yHandouts
+    if (!yHandouts) return
+    const existing = yHandouts.get(id)
+    if (existing) {
+      yHandouts.set(id, { ...existing, ...updates })
+    }
+  },
+
+  deleteHandoutAsset: (id: string) => {
+    get()._yHandouts?.delete(id)
+  },
+
+  // ── Team metrics actions ──
+  addTeamTracker: (label: string) => {
+    const yMetrics = get()._yMetrics
+    if (!yMetrics) return
+    const id =
+      self.crypto?.randomUUID?.() ??
+      Math.random().toString(36).slice(2) + Date.now().toString(36)
+    const count = yMetrics.size
+    const tracker: TeamTracker = {
+      id,
+      label,
+      current: 0,
+      max: 10,
+      color: DEFAULT_TRACKER_COLORS[count % DEFAULT_TRACKER_COLORS.length],
+      sortOrder: count,
+    }
+    yMetrics.set(id, tracker)
+  },
+
+  updateTeamTracker: (id: string, updates: Partial<TeamTracker>) => {
+    const yMetrics = get()._yMetrics
+    if (!yMetrics) return
+    const existing = yMetrics.get(id)
+    if (existing) {
+      yMetrics.set(id, { ...existing, ...updates })
+    }
+  },
+
+  deleteTeamTracker: (id: string) => {
+    get()._yMetrics?.delete(id)
+  },
+}))


### PR DESCRIPTION
## Summary
- 引入 zustand 作为 Yjs 和 React 之间的桥接层，替代原有 22 处手写 observer + useState 模式
- 创建三个 store:
  - **worldStore**: 所有 Yjs 数据（room, scenes, entities, tokens, showcase, handouts, blueprints, team metrics）
  - **identityStore**: 座位管理、会话持久化、Awareness 在线追踪
  - **uiStore**: 客户端 UI 状态（检视角色、选中 Token、右键菜单、编辑手册）
- 创建 **selectors.ts**: 派生数据（activeScene, isCombat, seatProperties, speakerEntities）
- App.tsx 重写为从 zustand store 读取数据，不再直接调用 Yjs observer hooks

## 架构
```
Yjs (网络同步层)
  ↓ observer → store.set()
zustand store (状态管理层)
  ↓ selector 订阅
React 组件 (渲染层)
```

## 迁移策略
- 增量迁移：旧 hooks（useScenes, useEntities, useRoom 等）保留不变，后续 WP 重写组件时逐步移除
- App.tsx 已切换到 store，子组件仍通过 props 接收数据（结构类型兼容）
- 子组件将在 Phase 2（视觉重写）和 Phase 3（Konva 迁移）中逐步改为直接从 store 读取

## Test Plan
- [x] `tsc -b` 无错误
- [x] `npm run build` 成功（136 modules, 1.00s）
- [x] 213/213 测试通过