### PR TITLE
feat: add feedback infrastructure (Toast, ErrorBoundary, DisconnectOverlay)

### DIFF
--- a/src/shared/ui/ConfirmDialog.tsx
+++ b/src/shared/ui/ConfirmDialog.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from 'react'
+
+interface ConfirmDialogProps {
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'warning'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'danger',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Auto-focus cancel button on mount
+  useEffect(() => {
+    cancelRef.current?.focus()
+  }, [])
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel])
+
+  // Focus trap: keep focus within dialog
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    const handleFocusTrap = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleFocusTrap)
+    return () => document.removeEventListener('keydown', handleFocusTrap)
+  }, [])
+
+  const confirmColorClass =
+    variant === 'danger'
+      ? 'bg-danger hover:bg-danger/80'
+      : 'bg-warning hover:bg-warning/80 text-deep'
+
+  return (
+    // Overlay
+    <div
+      className="fixed inset-0 z-modal flex items-center justify-center bg-deep/80 backdrop-blur-[4px]"
+      onClick={onCancel}
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby="confirm-dialog-message"
+    >
+      {/* Dialog card */}
+      <div
+        ref={dialogRef}
+        className="mx-4 max-w-sm w-full rounded-lg border border-border-glass bg-glass p-6 shadow-xl shadow-black/40 backdrop-blur-[12px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Title */}
+        <h2 id="confirm-dialog-title" className="text-lg font-semibold text-text-primary mb-2">
+          {title}
+        </h2>
+
+        {/* Message */}
+        <p id="confirm-dialog-message" className="text-sm text-text-muted mb-6 leading-relaxed">
+          {message}
+        </p>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <button
+            ref={cancelRef}
+            onClick={onCancel}
+            className="rounded-md border border-border-glass bg-transparent px-4 py-2 text-sm font-medium text-text-muted transition-colors duration-fast hover:bg-hover hover:text-text-primary motion-reduce:transition-none"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={[
+              'rounded-md px-4 py-2 text-sm font-medium text-text-primary',
+              'transition-colors duration-fast motion-reduce:transition-none',
+              confirmColorClass,
+            ].join(' ')}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/shared/ui/DisconnectOverlay.tsx
+++ b/src/shared/ui/DisconnectOverlay.tsx
@@ -1,0 +1,47 @@
+interface DisconnectOverlayProps {
+  isDisconnected: boolean
+}
+
+export function DisconnectOverlay({ isDisconnected }: DisconnectOverlayProps) {
+  if (!isDisconnected) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-overlay flex flex-col items-center justify-center bg-deep/85 backdrop-blur-[8px] animate-fade-in"
+      role="alert"
+      aria-live="assertive"
+    >
+      {/* Spinner */}
+      <div className="mb-6">
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          className="animate-spin text-accent"
+          aria-hidden="true"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="2"
+            fill="none"
+            opacity="0.25"
+          />
+          <path
+            d="M12 2a10 10 0 0 1 10 10"
+            stroke="currentColor"
+            strokeWidth="2"
+            fill="none"
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+
+      {/* Message */}
+      <h2 className="text-xl font-semibold text-text-primary mb-2">Connection lost</h2>
+      <p className="text-sm text-text-muted">Attempting to reconnect...</p>
+    </div>
+  )
+}

--- a/src/shared/ui/ErrorBoundary.tsx
+++ b/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,82 @@
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: (error: Error, reset: () => void) => ReactNode
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[ErrorBoundary]', error, info.componentStack)
+  }
+
+  private handleReset = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+    const { children, fallback } = this.props
+
+    if (error) {
+      if (fallback) {
+        return fallback(error, this.handleReset)
+      }
+
+      return (
+        <div className="flex items-center justify-center min-h-[200px] p-6">
+          <div className="max-w-md w-full rounded-lg border border-border-glass bg-surface p-6 shadow-lg shadow-black/30">
+            {/* Error icon */}
+            <div className="flex items-center gap-3 mb-4">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                className="shrink-0 text-danger"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" fill="none" />
+                <path
+                  d="M12 8v4M12 16v0"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+              </svg>
+              <h2 className="text-lg font-semibold text-text-primary">Something went wrong</h2>
+            </div>
+
+            {/* Error message */}
+            <p className="text-sm text-text-muted mb-4 break-words">
+              {error.message || 'An unexpected error occurred.'}
+            </p>
+
+            {/* Retry button */}
+            <button
+              onClick={this.handleReset}
+              className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-deep transition-colors duration-fast hover:bg-accent-bold motion-reduce:transition-none"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    return children
+  }
+}

--- a/src/shared/ui/Toast.tsx
+++ b/src/shared/ui/Toast.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react'
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info' | 'undo'
+
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
+export interface ToastData {
+  id: string
+  type: ToastType
+  message: string
+  action?: ToastAction
+  duration: number
+}
+
+interface ToastProps {
+  toast: ToastData
+  onDismiss: (id: string) => void
+}
+
+const icons: Record<ToastType, string> = {
+  success:
+    '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 12l2.5 2.5L16 9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>',
+  error:
+    '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/><path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>',
+  warning:
+    '<path d="M12 2L2 22h20L12 2z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/><path d="M12 10v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="12" cy="18" r="1" fill="currentColor"/>',
+  info: '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/><path d="M12 8v0M12 12v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>',
+  undo: '<path d="M3 7v6h6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M3 13a9 9 0 1 0 2.1-5.4L3 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>',
+}
+
+const typeColorClasses: Record<ToastType, string> = {
+  success: 'border-success text-success',
+  error: 'border-danger text-danger',
+  warning: 'border-warning text-warning',
+  info: 'border-info text-info',
+  undo: 'border-accent text-accent',
+}
+
+const actionButtonClasses: Record<ToastType, string> = {
+  success: 'bg-success hover:bg-success/80',
+  error: 'bg-danger hover:bg-danger/80',
+  warning: 'bg-warning hover:bg-warning/80 text-deep',
+  info: 'bg-info hover:bg-info/80',
+  undo: 'bg-accent hover:bg-accent/80 text-deep',
+}
+
+export function Toast({ toast, onDismiss }: ToastProps) {
+  const [visible, setVisible] = useState(false)
+  const [exiting, setExiting] = useState(false)
+
+  useEffect(() => {
+    // Trigger enter animation on next frame
+    const frame = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      handleDismiss()
+    }, toast.duration)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toast.duration, toast.id])
+
+  const handleDismiss = () => {
+    setExiting(true)
+    setTimeout(() => onDismiss(toast.id), 250)
+  }
+
+  const colorClasses = typeColorClasses[toast.type]
+
+  return (
+    <div
+      role="alert"
+      className={[
+        'pointer-events-auto flex items-center gap-3 rounded-lg border bg-glass px-4 py-3',
+        'backdrop-blur-[12px] shadow-lg shadow-black/30',
+        'transition-all duration-normal',
+        'motion-reduce:transition-none',
+        colorClasses,
+        visible && !exiting ? 'translate-x-0 opacity-100' : 'translate-x-4 opacity-0',
+      ].join(' ')}
+    >
+      {/* Icon */}
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        className="shrink-0"
+        dangerouslySetInnerHTML={{ __html: icons[toast.type] }}
+        aria-hidden="true"
+      />
+
+      {/* Message */}
+      <span className="text-sm text-text-primary flex-1 min-w-0">{toast.message}</span>
+
+      {/* Action button (for undo type) */}
+      {toast.action && (
+        <button
+          onClick={() => {
+            toast.action?.onClick()
+            handleDismiss()
+          }}
+          className={[
+            'shrink-0 rounded px-2.5 py-1 text-xs font-semibold',
+            'transition-colors duration-fast',
+            'motion-reduce:transition-none',
+            actionButtonClasses[toast.type],
+          ].join(' ')}
+        >
+          {toast.action.label}
+        </button>
+      )}
+
+      {/* Close button */}
+      <button
+        onClick={handleDismiss}
+        className="shrink-0 rounded p-1 text-text-muted hover:text-text-primary hover:bg-hover transition-colors duration-fast motion-reduce:transition-none"
+        aria-label="Close notification"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M18 6L6 18M6 6l12 12"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/src/shared/ui/ToastProvider.tsx
+++ b/src/shared/ui/ToastProvider.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { Toast } from './Toast.tsx'
+import type { ToastType } from './Toast.tsx'
+import { ToastContext } from './useToast.ts'
+import type { ToastOptions } from './useToast.ts'
+
+const DEFAULT_DURATION: Record<ToastType, number> = {
+  success: 4000,
+  error: 4000,
+  warning: 4000,
+  info: 4000,
+  undo: 5000,
+}
+
+const MAX_VISIBLE = 3
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<
+    {
+      id: string
+      type: ToastType
+      message: string
+      action?: { label: string; onClick: () => void }
+      duration: number
+    }[]
+  >([])
+  const counterRef = useRef(0)
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const addToast = useCallback(
+    (type: ToastType, message: string, options?: ToastOptions): string => {
+      const id = `toast-${++counterRef.current}`
+      const duration = options?.duration ?? DEFAULT_DURATION[type]
+
+      setToasts((prev) => {
+        const next = [...prev, { id, type, message, action: options?.action, duration }]
+        // FIFO: keep only the latest MAX_VISIBLE
+        if (next.length > MAX_VISIBLE) {
+          return next.slice(next.length - MAX_VISIBLE)
+        }
+        return next
+      })
+
+      return id
+    },
+    [],
+  )
+
+  return (
+    <ToastContext.Provider value={{ toast: addToast, dismiss }}>
+      {children}
+      {/* Toast container — fixed bottom-right */}
+      <div
+        className="fixed bottom-4 right-4 z-toast flex flex-col gap-2 pointer-events-none"
+        aria-live="polite"
+        aria-relevant="additions removals"
+      >
+        {toasts.map((t) => (
+          <Toast key={t.id} toast={t} onDismiss={dismiss} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/src/shared/ui/useToast.ts
+++ b/src/shared/ui/useToast.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react'
+import type { ToastType, ToastAction } from './Toast.tsx'
+
+export interface ToastOptions {
+  duration?: number
+  action?: ToastAction
+}
+
+export interface ToastContextValue {
+  toast: (type: ToastType, message: string, options?: ToastOptions) => string
+  dismiss: (id: string) => void
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return ctx
+}

--- a/src/yjs/useYjsConnection.ts
+++ b/src/yjs/useYjsConnection.ts
@@ -4,10 +4,13 @@ import { WebsocketProvider } from 'y-websocket'
 import type { Awareness } from 'y-protocols/awareness'
 import { WEBSOCKET_URL } from '../shared/config'
 
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected'
+
 export function useYjsConnection(roomId: string) {
   const [yDoc] = useState(() => new Y.Doc())
   const [isLoading, setIsLoading] = useState(true)
   const [awareness, setAwareness] = useState<Awareness | null>(null)
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting')
 
   useEffect(() => {
     const wsProvider = new WebsocketProvider(WEBSOCKET_URL, roomId, yDoc)
@@ -17,11 +20,15 @@ export function useYjsConnection(roomId: string) {
       if (synced) setIsLoading(false)
     })
 
+    wsProvider.on('status', (event: { status: ConnectionStatus }) => {
+      setConnectionStatus(event.status)
+    })
+
     return () => {
       wsProvider.destroy()
       setAwareness(null)
     }
   }, [yDoc, roomId])
 
-  return { yDoc, isLoading, awareness }
+  return { yDoc, isLoading, awareness, connectionStatus }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,6 +33,15 @@ export default {
         normal: '250ms',
         slow: '400ms',
       },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+      },
+      animation: {
+        'fade-in': 'fade-in 400ms ease-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- Toast notification system with 5 types (success/error/warning/info/undo), glass styling, auto-dismiss
- ErrorBoundary with styled fallback UI and retry button
- ConfirmDialog for destructive action confirmation (danger/warning variants)
- DisconnectOverlay for WebSocket connection loss with reconnecting indicator
- `useYjsConnection` hook now exposes `connectionStatus` state

## Test plan
- [x] TypeScript compiles without errors
- [x] All 213 tests pass
- [ ] Manual: trigger toast via `useToast()` hook, verify appearance and auto-dismiss
- [ ] Manual: simulate disconnect, verify overlay appears