### PR TITLE
feat: add tactical map floating panel overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { roleStore } from './shared/roleState'
 import { SeatSelect } from './identity/SeatSelect'
 import { ChatPanel } from './chat/ChatPanel'
 import { SceneViewer } from './scene/SceneViewer'
-import { CombatViewer } from './combat/CombatViewer'
+import { TacticalPanel } from './combat/TacticalPanel'
 import { BottomDock } from './dock/BottomDock'
 
 import { GmToolbar } from './gm/GmToolbar'
@@ -262,8 +262,10 @@ function RoomSession({ roomId }: { roomId: string }) {
 
   return (
     <div>
-      {isCombat ? (
-        <CombatViewer
+      <SceneViewer scene={activeScene} onContextMenu={handleBgContextMenu} />
+
+      {isCombat && (
+        <TacticalPanel
           scene={activeScene}
           tokens={tokens}
           getEntity={getEntity}
@@ -273,9 +275,10 @@ function RoomSession({ roomId }: { roomId: string }) {
           onSelectToken={setSelectedTokenId}
           onUpdateToken={updateToken}
           onContextMenu={handleBgContextMenu}
+          onClose={() => {
+            if (room.activeSceneId) setCombatActive(room.activeSceneId, false)
+          }}
         />
-      ) : (
-        <SceneViewer scene={activeScene} onContextMenu={handleBgContextMenu} />
       )}
 
       {/* Top-left: Hamburger menu */}

--- a/src/combat/CombatViewer.tsx
+++ b/src/combat/CombatViewer.tsx
@@ -32,8 +32,8 @@ export function CombatViewer({
       <div
         onContextMenu={onContextMenu}
         style={{
-          width: '100vw',
-          height: '100vh',
+          width: '100%',
+          height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -52,8 +52,8 @@ export function CombatViewer({
     <div
       onContextMenu={onContextMenu}
       style={{
-        width: '100vw',
-        height: '100vh',
+        width: '100%',
+        height: '100%',
         overflow: 'hidden',
         background: '#111',
       }}

--- a/src/combat/TacticalPanel.tsx
+++ b/src/combat/TacticalPanel.tsx
@@ -1,0 +1,91 @@
+import type { Scene } from '../stores/worldStore'
+import type { MapToken, Entity } from '../shared/entityTypes'
+import { CombatViewer } from './CombatViewer'
+
+interface TacticalPanelProps {
+  scene: Scene | null
+  tokens: MapToken[]
+  getEntity: (id: string) => Entity | null
+  mySeatId: string
+  role: 'GM' | 'PL'
+  selectedTokenId: string | null
+  onSelectToken: (id: string | null) => void
+  onUpdateToken: (id: string, updates: Partial<MapToken>) => void
+  onContextMenu?: (e: React.MouseEvent) => void
+  onClose: () => void
+}
+
+export function TacticalPanel({
+  scene,
+  tokens,
+  getEntity,
+  mySeatId,
+  role,
+  selectedTokenId,
+  onSelectToken,
+  onUpdateToken,
+  onContextMenu,
+  onClose,
+}: TacticalPanelProps) {
+  return (
+    <div
+      className="bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
+      style={{
+        position: 'fixed',
+        top: '15vh',
+        left: '15vw',
+        width: '70vw',
+        height: '70vh',
+        zIndex: 10001,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header bar */}
+      <div
+        className="border-b border-border-glass"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '8px 16px',
+          flexShrink: 0,
+        }}
+      >
+        <span className="text-text-primary" style={{ fontSize: 14, fontWeight: 500 }}>
+          Tactical Map
+        </span>
+        <button
+          onClick={onClose}
+          className="text-text-muted hover:text-text-primary"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: 18,
+            lineHeight: 1,
+            padding: '4px 8px',
+          }}
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Panel body */}
+      <div style={{ flex: 1, overflow: 'hidden' }}>
+        <CombatViewer
+          scene={scene}
+          tokens={tokens}
+          getEntity={getEntity}
+          mySeatId={mySeatId}
+          role={role}
+          selectedTokenId={selectedTokenId}
+          onSelectToken={onSelectToken}
+          onUpdateToken={onUpdateToken}
+          onContextMenu={onContextMenu}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- SceneViewer now renders unconditionally as atmospheric background
- New TacticalPanel component floats on top when combat is active (70vw x 70vh centered, glass-styled)
- CombatViewer sizing changed from viewport units to 100% for panel embedding
- Combat state remains Yjs-synced via `combatActive` on the scene Y.Map

## Test plan
- [x] TypeScript compiles without errors
- [x] All 213 tests pass
- [ ] Manual: toggle combat on a scene, verify tactical panel overlays scene background
- [ ] Manual: close tactical panel via X button, verify combat deactivates
- [ ] Manual: switch scenes while combat is active, verify panel closes on new scene