### PR TITLE
feat: scene management UI (SceneListPanel + SceneConfigPanel)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,7 +360,6 @@ function RoomSession({ roomId }: { roomId: string }) {
           onToggleCombat={() => {
             if (room.activeSceneId) setCombatActive(room.activeSceneId, !isCombat)
           }}
-          onAddScene={handleAddScene}
           onUpdateScene={updateScene}
           onDeleteScene={handleDeleteScene}
         />

--- a/src/gm/GmToolbar.tsx
+++ b/src/gm/GmToolbar.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
+import { Image, Swords, Layout, BookOpen } from 'lucide-react'
 import type { Scene } from '../yjs/useScenes'
-import { SceneLibrary } from './SceneLibrary'
-import { isVideoUrl } from '../shared/assetUpload'
+import { SceneListPanel } from './SceneListPanel'
+import { SceneConfigPanel } from './SceneConfigPanel'
 
 interface GmToolbarProps {
   scenes: Scene[]
@@ -9,7 +10,6 @@ interface GmToolbarProps {
   isCombat: boolean
   onSelectScene: (sceneId: string) => void
   onToggleCombat: () => void
-  onAddScene: (scene: Scene) => void
   onUpdateScene: (id: string, updates: Partial<Scene>) => void
   onDeleteScene: (id: string) => void
 }
@@ -20,231 +20,104 @@ export function GmToolbar({
   isCombat,
   onSelectScene,
   onToggleCombat,
-  onAddScene,
   onUpdateScene,
   onDeleteScene,
 }: GmToolbarProps) {
-  const [showScenePicker, setShowScenePicker] = useState(false)
-  const [showLibrary, setShowLibrary] = useState(false)
+  const [showSceneList, setShowSceneList] = useState(false)
+  const [editingSceneId, setEditingSceneId] = useState<string | null>(null)
+
+  const editingScene = editingSceneId ? (scenes.find((s) => s.id === editingSceneId) ?? null) : null
+
+  const handleEditScene = useCallback((sceneId: string) => {
+    setEditingSceneId(sceneId)
+  }, [])
+
+  const handleCloseSceneList = useCallback(() => {
+    setShowSceneList(false)
+  }, [])
+
+  const handleCloseConfig = useCallback(() => {
+    setEditingSceneId(null)
+  }, [])
+
+  const toolbarBtnClass =
+    'flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold cursor-pointer transition-colors duration-fast'
+
+  const defaultBtnClass = `${toolbarBtnClass} bg-glass backdrop-blur-[12px] border border-border-glass text-text-primary hover:bg-hover`
 
   return (
     <>
       {/* Toolbar */}
       <div
-        style={{
-          position: 'fixed',
-          bottom: 12,
-          left: 16,
-          zIndex: 10000,
-          display: 'flex',
-          gap: 6,
-          fontFamily: 'sans-serif',
-        }}
+        className="fixed z-toast flex gap-1.5"
+        style={{ bottom: 12, left: 16 }}
         onPointerDown={(e) => e.stopPropagation()}
       >
-        {/* Scene picker */}
-        <div style={{ position: 'relative' }}>
-          <button
-            onClick={() => setShowScenePicker(!showScenePicker)}
-            style={{
-              padding: '8px 14px',
-              background: 'rgba(255,255,255,0.92)',
-              backdropFilter: 'blur(8px)',
-              border: 'none',
-              borderRadius: 8,
-              fontSize: 12,
-              fontWeight: 600,
-              cursor: 'pointer',
-              boxShadow: '0 2px 12px rgba(0,0,0,0.15)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-            }}
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <rect x="3" y="3" width="18" height="18" rx="2" />
-              <circle cx="8.5" cy="8.5" r="1.5" />
-              <path d="M21 15l-5-5L5 21" />
-            </svg>
-            Scenes
-          </button>
+        {/* 1. Scene management */}
+        <button
+          onClick={() => {
+            setShowSceneList(!showSceneList)
+            if (!showSceneList) setEditingSceneId(null)
+          }}
+          className={`${toolbarBtnClass} ${
+            showSceneList
+              ? 'bg-accent/20 backdrop-blur-[12px] border border-accent/40 text-accent-bold'
+              : 'bg-glass backdrop-blur-[12px] border border-border-glass text-text-primary hover:bg-hover'
+          }`}
+          title="Scene management"
+        >
+          <Image size={16} strokeWidth={1.5} />
+          Scenes
+        </button>
 
-          {/* Scene dropdown */}
-          {showScenePicker && (
-            <div
-              style={{
-                position: 'absolute',
-                bottom: '100%',
-                left: 0,
-                marginBottom: 6,
-                background: 'rgba(255,255,255,0.96)',
-                backdropFilter: 'blur(8px)',
-                borderRadius: 10,
-                boxShadow: '0 4px 24px rgba(0,0,0,0.15)',
-                minWidth: 200,
-                maxHeight: 300,
-                overflowY: 'auto',
-                padding: 4,
-              }}
-            >
-              {scenes.length === 0 && (
-                <div
-                  style={{ padding: '12px 16px', color: '#999', fontSize: 12, textAlign: 'center' }}
-                >
-                  No scenes yet
-                </div>
-              )}
-              {scenes.map((scene) => (
-                <button
-                  key={scene.id}
-                  onClick={() => {
-                    onSelectScene(scene.id)
-                    setShowScenePicker(false)
-                  }}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    width: '100%',
-                    padding: '8px 12px',
-                    background: scene.id === activeSceneId ? 'rgba(59,130,246,0.1)' : 'transparent',
-                    border: 'none',
-                    borderRadius: 6,
-                    cursor: 'pointer',
-                    fontSize: 12,
-                    textAlign: 'left',
-                  }}
-                >
-                  {isVideoUrl(scene.atmosphereImageUrl) ? (
-                    <video
-                      src={scene.atmosphereImageUrl}
-                      muted
-                      playsInline
-                      style={{
-                        width: 36,
-                        height: 24,
-                        objectFit: 'cover',
-                        borderRadius: 3,
-                        flexShrink: 0,
-                      }}
-                    />
-                  ) : (
-                    <img
-                      src={scene.atmosphereImageUrl}
-                      alt=""
-                      style={{
-                        width: 36,
-                        height: 24,
-                        objectFit: 'cover',
-                        borderRadius: 3,
-                        flexShrink: 0,
-                      }}
-                    />
-                  )}
-                  <span
-                    style={{
-                      fontWeight: scene.id === activeSceneId ? 600 : 400,
-                      color: '#333',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {scene.name || 'Untitled'}
-                  </span>
-                </button>
-              ))}
-              <div style={{ borderTop: '1px solid #eee', margin: '4px 0' }} />
-              <button
-                onClick={() => {
-                  setShowScenePicker(false)
-                  setShowLibrary(true)
-                }}
-                style={{
-                  width: '100%',
-                  padding: '8px 12px',
-                  background: 'transparent',
-                  border: 'none',
-                  borderRadius: 6,
-                  cursor: 'pointer',
-                  fontSize: 12,
-                  color: '#2563eb',
-                  fontWeight: 600,
-                  textAlign: 'left',
-                }}
-              >
-                Manage Scenes...
-              </button>
-            </div>
-          )}
-        </div>
-
-        {/* Combat toggle */}
+        {/* 2. Tactical toggle */}
         <button
           onClick={onToggleCombat}
-          style={{
-            padding: '8px 14px',
-            background: isCombat ? 'rgba(239,68,68,0.9)' : 'rgba(255,255,255,0.92)',
-            backdropFilter: 'blur(8px)',
-            border: 'none',
-            borderRadius: 8,
-            fontSize: 12,
-            fontWeight: 600,
-            color: isCombat ? '#fff' : '#333',
-            cursor: 'pointer',
-            boxShadow: '0 2px 12px rgba(0,0,0,0.15)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-          }}
+          className={`${toolbarBtnClass} ${
+            isCombat
+              ? 'bg-danger backdrop-blur-[12px] border border-danger text-text-primary'
+              : 'bg-glass backdrop-blur-[12px] border border-border-glass text-text-primary hover:bg-hover'
+          }`}
+          title={isCombat ? 'Exit combat mode' : 'Enter combat mode'}
         >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            {isCombat ? (
-              <>
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </>
-            ) : (
-              <>
-                <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-                <polyline points="14 2 14 8 20 8" />
-              </>
-            )}
-          </svg>
+          <Swords size={16} strokeWidth={1.5} />
           {isCombat ? 'Exit Combat' : 'Combat'}
+        </button>
+
+        {/* 3. Asset dock toggle (placeholder) */}
+        <button className={defaultBtnClass} title="Asset library">
+          <Layout size={16} strokeWidth={1.5} />
+          Assets
+        </button>
+
+        {/* 4. Showcase (placeholder) */}
+        <button className={defaultBtnClass} title="Showcase / Handouts">
+          <BookOpen size={16} strokeWidth={1.5} />
+          Showcase
         </button>
       </div>
 
-      {/* Scene Library Modal */}
-      {showLibrary && (
-        <SceneLibrary
+      {/* Scene List Panel */}
+      {showSceneList && (
+        <SceneListPanel
           scenes={scenes}
-          onClose={() => setShowLibrary(false)}
-          onAdd={onAddScene}
-          onUpdate={onUpdateScene}
-          onDelete={onDeleteScene}
-          onSelect={(id) => {
-            onSelectScene(id)
-            setShowLibrary(false)
+          activeSceneId={activeSceneId}
+          onSelectScene={onSelectScene}
+          onEditScene={handleEditScene}
+          onClose={handleCloseSceneList}
+        />
+      )}
+
+      {/* Scene Config Panel */}
+      {editingScene && (
+        <SceneConfigPanel
+          scene={editingScene}
+          onUpdateScene={onUpdateScene}
+          onDeleteScene={(id) => {
+            onDeleteScene(id)
+            setEditingSceneId(null)
           }}
+          onClose={handleCloseConfig}
         />
       )}
     </>

--- a/src/gm/SceneConfigPanel.tsx
+++ b/src/gm/SceneConfigPanel.tsx
@@ -1,0 +1,249 @@
+import { useState, useEffect, useRef } from 'react'
+import { X, Trash2 } from 'lucide-react'
+import type { Scene } from '../yjs/useScenes'
+
+interface SceneConfigPanelProps {
+  scene: Scene
+  onUpdateScene: (id: string, updates: Partial<Scene>) => void
+  onDeleteScene: (id: string) => void
+  onClose: () => void
+}
+
+const PARTICLE_PRESETS = ['none', 'embers', 'snow', 'dust', 'rain', 'fireflies'] as const
+
+export function SceneConfigPanel({
+  scene,
+  onUpdateScene,
+  onDeleteScene,
+  onClose,
+}: SceneConfigPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  const [name, setName] = useState(scene.name)
+  const [particlePreset, setParticlePreset] = useState(scene.particlePreset)
+  const [gridVisible, setGridVisible] = useState(scene.gridVisible)
+  const [gridSize, setGridSize] = useState(scene.gridSize)
+  const [gridSnap, setGridSnap] = useState(scene.gridSnap)
+  const [gridColor, setGridColor] = useState(scene.gridColor)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  // Reset form when scene changes
+  useEffect(() => {
+    setName(scene.name)
+    setParticlePreset(scene.particlePreset)
+    setGridVisible(scene.gridVisible)
+    setGridSize(scene.gridSize)
+    setGridSnap(scene.gridSnap)
+    setGridColor(scene.gridColor)
+    setConfirmDelete(false)
+  }, [
+    scene.id,
+    scene.name,
+    scene.particlePreset,
+    scene.gridVisible,
+    scene.gridSize,
+    scene.gridSnap,
+    scene.gridColor,
+  ])
+
+  // Click-outside-to-close
+  useEffect(() => {
+    const handler = (e: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('pointerdown', handler)
+    return () => document.removeEventListener('pointerdown', handler)
+  }, [onClose])
+
+  const handleSave = () => {
+    onUpdateScene(scene.id, {
+      name: name.trim() || 'Untitled',
+      particlePreset,
+      gridVisible,
+      gridSize,
+      gridSnap,
+      gridColor,
+    })
+    onClose()
+  }
+
+  const handleDelete = () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true)
+      return
+    }
+    onDeleteScene(scene.id)
+    onClose()
+  }
+
+  const inputClass =
+    'w-full bg-surface text-text-primary text-xs rounded px-2 py-1.5 border border-border-glass focus:border-accent focus:outline-none transition-colors duration-fast'
+
+  const labelClass = 'text-text-muted text-xs font-medium'
+
+  return (
+    <div
+      ref={panelRef}
+      className="fixed z-toast bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)] flex flex-col"
+      style={{ bottom: 56, left: 286, width: 300, maxHeight: 520 }}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border-glass">
+        <span className="text-text-primary text-sm font-semibold">Scene Settings</span>
+        <button
+          onClick={onClose}
+          className="text-text-muted hover:text-text-primary transition-colors duration-fast p-0.5 cursor-pointer"
+        >
+          <X size={16} strokeWidth={1.5} />
+        </button>
+      </div>
+
+      {/* Form */}
+      <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-3">
+        {/* Scene name */}
+        <div className="flex flex-col gap-1">
+          <label className={labelClass}>Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={inputClass}
+            placeholder="Scene name"
+          />
+        </div>
+
+        {/* Atmosphere image (read-only) */}
+        <div className="flex flex-col gap-1">
+          <label className={labelClass}>Atmosphere Image</label>
+          <div className="text-text-muted text-xs bg-surface rounded px-2 py-1.5 border border-border-glass truncate">
+            {scene.atmosphereImageUrl || 'None — set via asset dock'}
+          </div>
+        </div>
+
+        {/* Tactical map (read-only) */}
+        <div className="flex flex-col gap-1">
+          <label className={labelClass}>Tactical Map</label>
+          <div className="text-text-muted text-xs bg-surface rounded px-2 py-1.5 border border-border-glass truncate">
+            {scene.tacticalMapImageUrl || 'None — set via asset dock'}
+          </div>
+        </div>
+
+        {/* Particle preset */}
+        <div className="flex flex-col gap-1">
+          <label className={labelClass}>Particle Effect</label>
+          <select
+            value={particlePreset}
+            onChange={(e) => setParticlePreset(e.target.value)}
+            className={inputClass}
+          >
+            {PARTICLE_PRESETS.map((preset) => (
+              <option key={preset} value={preset}>
+                {preset.charAt(0).toUpperCase() + preset.slice(1)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Grid settings section */}
+        <div className="flex flex-col gap-2">
+          <span className="text-text-muted text-xs font-semibold uppercase tracking-wide">
+            Grid
+          </span>
+
+          {/* Grid visible toggle */}
+          <label className="flex items-center justify-between cursor-pointer">
+            <span className={labelClass}>Visible</span>
+            <button
+              type="button"
+              onClick={() => setGridVisible(!gridVisible)}
+              className={`w-8 h-4.5 rounded-full transition-colors duration-fast cursor-pointer ${
+                gridVisible ? 'bg-accent' : 'bg-surface border border-border-glass'
+              }`}
+            >
+              <div
+                className={`w-3.5 h-3.5 rounded-full bg-text-primary transition-transform duration-fast ${
+                  gridVisible ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </label>
+
+          {/* Grid size */}
+          <div className="flex items-center justify-between gap-2">
+            <label className={labelClass}>Size (px)</label>
+            <input
+              type="number"
+              value={gridSize}
+              onChange={(e) => setGridSize(Math.max(10, parseInt(e.target.value) || 10))}
+              className="w-20 bg-surface text-text-primary text-xs rounded px-2 py-1.5 border border-border-glass focus:border-accent focus:outline-none transition-colors duration-fast"
+              min={10}
+              max={500}
+            />
+          </div>
+
+          {/* Grid snap toggle */}
+          <label className="flex items-center justify-between cursor-pointer">
+            <span className={labelClass}>Snap to Grid</span>
+            <button
+              type="button"
+              onClick={() => setGridSnap(!gridSnap)}
+              className={`w-8 h-4.5 rounded-full transition-colors duration-fast cursor-pointer ${
+                gridSnap ? 'bg-accent' : 'bg-surface border border-border-glass'
+              }`}
+            >
+              <div
+                className={`w-3.5 h-3.5 rounded-full bg-text-primary transition-transform duration-fast ${
+                  gridSnap ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </label>
+
+          {/* Grid color */}
+          <div className="flex items-center justify-between gap-2">
+            <label className={labelClass}>Color</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                value={gridColor.startsWith('rgba') ? '#ffffff' : gridColor}
+                onChange={(e) => setGridColor(e.target.value)}
+                className="w-6 h-6 rounded border border-border-glass cursor-pointer bg-transparent"
+              />
+              <input
+                type="text"
+                value={gridColor}
+                onChange={(e) => setGridColor(e.target.value)}
+                className="w-28 bg-surface text-text-primary text-xs rounded px-2 py-1.5 border border-border-glass focus:border-accent focus:outline-none transition-colors duration-fast"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-3 py-2 border-t border-border-glass">
+        {/* Delete button */}
+        <button
+          onClick={handleDelete}
+          className={`flex items-center gap-1 text-xs font-medium px-2 py-1.5 rounded transition-colors duration-fast cursor-pointer ${
+            confirmDelete ? 'bg-danger text-text-primary' : 'text-danger hover:bg-danger/15'
+          }`}
+        >
+          <Trash2 size={14} strokeWidth={1.5} />
+          {confirmDelete ? 'Confirm Delete' : 'Delete'}
+        </button>
+
+        {/* Save button */}
+        <button
+          onClick={handleSave}
+          className="bg-accent hover:bg-accent-bold text-deep text-xs font-semibold px-4 py-1.5 rounded transition-colors duration-fast cursor-pointer"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/gm/SceneListPanel.tsx
+++ b/src/gm/SceneListPanel.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+import { X, Pencil } from 'lucide-react'
+import type { Scene } from '../yjs/useScenes'
+import { isVideoUrl } from '../shared/assetUpload'
+
+interface SceneListPanelProps {
+  scenes: Scene[]
+  activeSceneId: string | null
+  onSelectScene: (sceneId: string) => void
+  onEditScene: (sceneId: string) => void
+  onClose: () => void
+}
+
+export function SceneListPanel({
+  scenes,
+  activeSceneId,
+  onSelectScene,
+  onEditScene,
+  onClose,
+}: SceneListPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Click-outside-to-close
+  useEffect(() => {
+    const handler = (e: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('pointerdown', handler)
+    return () => document.removeEventListener('pointerdown', handler)
+  }, [onClose])
+
+  return (
+    <div
+      ref={panelRef}
+      className="fixed z-toast bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)] flex flex-col"
+      style={{ bottom: 56, left: 16, width: 260, maxHeight: 400 }}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border-glass">
+        <span className="text-text-primary text-sm font-semibold">Scenes</span>
+        <button
+          onClick={onClose}
+          className="text-text-muted hover:text-text-primary transition-colors duration-fast p-0.5 cursor-pointer"
+        >
+          <X size={16} strokeWidth={1.5} />
+        </button>
+      </div>
+
+      {/* Scene list */}
+      <div className="flex-1 overflow-y-auto p-1.5">
+        {scenes.length === 0 ? (
+          <div className="text-text-muted text-xs text-center py-8 px-4">
+            No scenes yet. Upload from the asset dock.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {scenes.map((scene) => {
+              const isActive = scene.id === activeSceneId
+              return (
+                <div
+                  key={scene.id}
+                  className={`flex items-center gap-2 rounded-md px-2 py-1.5 cursor-pointer transition-colors duration-fast group ${
+                    isActive
+                      ? 'bg-accent/15 border border-accent/30'
+                      : 'border border-transparent hover:bg-hover'
+                  }`}
+                  onClick={() => onSelectScene(scene.id)}
+                >
+                  {/* Thumbnail */}
+                  <div className="w-12 h-8 rounded overflow-hidden flex-shrink-0 bg-deep">
+                    {scene.atmosphereImageUrl ? (
+                      isVideoUrl(scene.atmosphereImageUrl) ? (
+                        <video
+                          src={scene.atmosphereImageUrl}
+                          muted
+                          playsInline
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <img
+                          src={scene.atmosphereImageUrl}
+                          alt=""
+                          className="w-full h-full object-cover"
+                        />
+                      )
+                    ) : (
+                      <div className="w-full h-full bg-surface" />
+                    )}
+                  </div>
+
+                  {/* Name */}
+                  <span
+                    className={`flex-1 text-xs truncate ${
+                      isActive ? 'text-accent-bold font-semibold' : 'text-text-primary'
+                    }`}
+                  >
+                    {scene.name || 'Untitled'}
+                  </span>
+
+                  {/* Edit button */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onEditScene(scene.id)
+                    }}
+                    className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-accent transition-all duration-fast p-1 cursor-pointer"
+                    title="Edit scene"
+                  >
+                    <Pencil size={14} strokeWidth={1.5} />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `SceneListPanel` with scene thumbnails, active-scene highlight, and per-scene edit button
- Add `SceneConfigPanel` with name, particle preset, grid settings, and 2-click delete confirmation
- Redesign `GmToolbar` with 4-button layout (Scenes, Combat, Assets, Showcase) using Lucide icons
- Remove unused `onAddScene` prop from GmToolbar interface
- All new components use Tailwind design tokens and glass panel styling

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 213 tests pass
- [ ] Manual: GM toolbar shows 4 buttons with correct icons
- [ ] Manual: Scenes button opens scene list panel with thumbnails
- [ ] Manual: Pencil icon opens scene config panel
- [ ] Manual: Scene config save/delete works correctly
- [ ] Manual: Click-outside-to-close works for both panels