### PR TITLE
feat: add empty state guidance for all content areas

### DIFF
--- a/src/chat/MessageScrollArea.tsx
+++ b/src/chat/MessageScrollArea.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from 'react'
+import { MessageSquare } from 'lucide-react'
 import type { ChatMessage } from './chatTypes'
 import { MessageCard } from './MessageCard'
 
@@ -90,14 +91,22 @@ export function MessageScrollArea({ messages, newMessageIds }: MessageScrollArea
           onScroll={checkIfAtBottom}
           onWheel={(e) => e.stopPropagation()}
         >
-          {messages.map((msg) => (
-            <MessageCard
-              key={msg.id}
-              message={msg}
-              isNew={newMessageIds.has(msg.id)}
-              animationStyle="scroll"
-            />
-          ))}
+          {messages.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+              <MessageSquare size={32} strokeWidth={1} className="text-text-muted/40" />
+              <p className="text-text-muted text-sm">No messages yet</p>
+              <p className="text-text-muted/50 text-xs">Start the adventure!</p>
+            </div>
+          ) : (
+            messages.map((msg) => (
+              <MessageCard
+                key={msg.id}
+                message={msg}
+                isNew={newMessageIds.has(msg.id)}
+                animationStyle="scroll"
+              />
+            ))
+          )}
         </div>
       </div>
     </>

--- a/src/dock/HandoutDockTab.tsx
+++ b/src/dock/HandoutDockTab.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Pencil, X, Plus, Loader } from 'lucide-react'
+import { Pencil, X, Plus, Loader, FileImage } from 'lucide-react'
 import type { HandoutAsset } from './useHandoutAssets'
 import { uploadAsset } from '../shared/assetUpload'
 import { generateTokenId } from '../shared/idUtils'
@@ -45,6 +45,14 @@ export function HandoutDockTab({
         className="hidden"
         onChange={handleUpload}
       />
+      {assets.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <FileImage size={32} strokeWidth={1} className="text-text-muted/40" />
+          <p className="text-text-muted text-sm">No handouts yet</p>
+          <p className="text-text-muted/50 text-xs">Upload images to share with your players</p>
+        </div>
+      )}
+
       <div
         className="grid gap-2"
         style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(100px, 1fr))' }}

--- a/src/dock/MapDockTab.tsx
+++ b/src/dock/MapDockTab.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { X, Plus } from 'lucide-react'
+import { X, Plus, Map } from 'lucide-react'
 import type { Scene } from '../yjs/useScenes'
 import { uploadAsset, getMediaDimensions, isVideoUrl } from '../shared/assetUpload'
 import { generateTokenId } from '../shared/idUtils'
@@ -66,6 +66,14 @@ export function MapDockTab({
         className="hidden"
         onChange={handleUpload}
       />
+
+      {scenes.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <Map size={32} strokeWidth={1} className="text-text-muted/40" />
+          <p className="text-text-muted text-sm">No maps yet</p>
+          <p className="text-text-muted/50 text-xs">Upload an image to create your first scene</p>
+        </div>
+      )}
 
       <div
         className="grid gap-2"

--- a/src/dock/TokenDockTab.tsx
+++ b/src/dock/TokenDockTab.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { X, Plus } from 'lucide-react'
+import { X, Plus, CircleDot } from 'lucide-react'
 import type { Blueprint } from '../shared/entityTypes'
 import { uploadAsset } from '../shared/assetUpload'
 import { generateTokenId } from '../shared/idUtils'
@@ -94,6 +94,14 @@ export function TokenDockTab({
         className="hidden"
         onChange={handleUpload}
       />
+
+      {blueprints.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <CircleDot size={32} strokeWidth={1} className="text-text-muted/40" />
+          <p className="text-text-muted text-sm">No token blueprints</p>
+          <p className="text-text-muted/50 text-xs">Upload token images to build your collection</p>
+        </div>
+      )}
 
       <div
         className="grid gap-2.5"

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
+import { Users } from 'lucide-react'
 import type { Entity } from '../shared/entityTypes'
 import { canSee, canEdit } from '../shared/permissions'
 import { getEntityResources, getEntityStatuses } from '../shared/entityAdapters'
@@ -173,7 +174,16 @@ export function PortraitBar({
       (mySeatId ? canSee(e.permissions, mySeatId, role) : isGM),
   )
 
-  if (visibleEntities.length === 0) return null
+  if (visibleEntities.length === 0) {
+    return (
+      <div className="fixed top-3 left-1/2 -translate-x-1/2 z-toast pointer-events-none flex flex-col items-center">
+        <div className="flex items-center gap-1.5 bg-glass backdrop-blur-[16px] rounded-[28px] px-4 py-2 shadow-[0_4px_20px_rgba(0,0,0,0.25)] border border-border-glass pointer-events-auto">
+          <Users size={14} strokeWidth={1.5} className="text-text-muted/40" />
+          <span className="text-text-muted/40 text-[11px]">No characters yet</span>
+        </div>
+      </div>
+    )
+  }
 
   // Split by ownership: "party" entities (owner exists) vs scene entities (no owners)
   const partyEntities = visibleEntities.filter((e) =>

--- a/src/scene/SceneViewer.tsx
+++ b/src/scene/SceneViewer.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { Image } from 'lucide-react'
 import type { Scene } from '../yjs/useScenes'
 import { isVideoUrl } from '../shared/assetUpload'
 import { ParticleLayer } from './ParticleLayer'
@@ -39,19 +40,13 @@ export function SceneViewer({ scene, onContextMenu }: SceneViewerProps) {
     return (
       <div
         onContextMenu={onContextMenu}
-        style={{
-          width: '100vw',
-          height: '100vh',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: '#1a1a2e',
-          color: '#666',
-          fontFamily: 'sans-serif',
-          fontSize: 16,
-        }}
+        className="w-screen h-screen flex items-center justify-center bg-deep"
       >
-        No scene selected
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <Image size={32} strokeWidth={1} className="text-text-muted/40" />
+          <p className="text-text-muted text-sm">No scene selected</p>
+          <p className="text-text-muted/50 text-xs">Upload a scene from the asset dock</p>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Add Lucide icon + descriptive text empty states for 6 content areas
- Scene viewer, portrait bar, chat messages, map dock, token dock, handout dock
- Uses design token colors (text-text-muted) for consistent warm-theme styling

## Test plan
- [ ] Verify empty states appear when no content exists in each area
- [ ] Confirm empty states disappear when content is added
- [ ] Build passes, 213 tests pass