### PR TITLE
feat: add token context menu, hover tooltip, and grid snap ghost preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -274,6 +274,8 @@ function RoomSession({ roomId }: { roomId: string }) {
           selectedTokenId={selectedTokenId}
           onSelectToken={setSelectedTokenId}
           onUpdateToken={updateToken}
+          onDeleteToken={deleteToken}
+          onAddToken={addToken}
           onContextMenu={handleBgContextMenu}
           onClose={() => {
             if (room.activeSceneId) setCombatActive(room.activeSceneId, false)

--- a/src/combat/GhostToken.tsx
+++ b/src/combat/GhostToken.tsx
@@ -1,0 +1,29 @@
+import { Group, Circle } from 'react-konva'
+
+interface GhostTokenProps {
+  x: number
+  y: number
+  pixelSize: number
+  color: string
+}
+
+export function GhostToken({ x, y, pixelSize, color }: GhostTokenProps) {
+  const radius = pixelSize / 2
+
+  return (
+    <Group x={x} y={y} listening={false}>
+      {/* Semi-transparent fill */}
+      <Circle x={radius} y={radius} radius={radius} fill={color} opacity={0.3} />
+      {/* Dashed border ring */}
+      <Circle
+        x={radius}
+        y={radius}
+        radius={radius}
+        stroke={color}
+        strokeWidth={2}
+        dash={[6, 4]}
+        opacity={0.6}
+      />
+    </Group>
+  )
+}

--- a/src/combat/KonvaMap.tsx
+++ b/src/combat/KonvaMap.tsx
@@ -6,7 +6,38 @@ import type { Scene } from '../stores/worldStore'
 import { isVideoUrl } from '../shared/assetUpload'
 import { KonvaGrid } from './KonvaGrid'
 import { KonvaTokenLayer } from './KonvaTokenLayer'
+import type { TokenContextMenuEvent, TokenHoverEvent } from './KonvaTokenLayer'
+import { TokenContextMenu } from './TokenContextMenu'
+import { TokenTooltip } from './TokenTooltip'
 import { useImage } from './useImage'
+import { generateTokenId } from '../shared/idUtils'
+import { snapToGrid } from './combatUtils'
+
+// Random pastel-ish colors for new tokens
+const TOKEN_COLORS = [
+  '#e74c3c',
+  '#3498db',
+  '#2ecc71',
+  '#9b59b6',
+  '#f39c12',
+  '#1abc9c',
+  '#e67e22',
+  '#e91e63',
+  '#00bcd4',
+  '#8bc34a',
+]
+
+function randomColor(): string {
+  return TOKEN_COLORS[Math.floor(Math.random() * TOKEN_COLORS.length)]
+}
+
+interface ContextMenuState {
+  screenX: number
+  screenY: number
+  tokenId: string | null
+  mapX: number
+  mapY: number
+}
 
 interface KonvaMapProps {
   scene: Scene | null
@@ -17,6 +48,8 @@ interface KonvaMapProps {
   selectedTokenId: string | null
   onSelectToken: (id: string | null) => void
   onUpdateToken: (id: string, updates: Partial<MapToken>) => void
+  onDeleteToken: (id: string) => void
+  onAddToken: (token: MapToken) => void
 }
 
 const MIN_SCALE = 0.1
@@ -32,6 +65,8 @@ export function KonvaMap({
   selectedTokenId,
   onSelectToken,
   onUpdateToken,
+  onDeleteToken,
+  onAddToken,
 }: KonvaMapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const stageRef = useRef<Konva.Stage>(null)
@@ -39,10 +74,24 @@ export function KonvaMap({
   const [stageScale, setStageScale] = useState(1)
   const [stagePos, setStagePos] = useState({ x: 0, y: 0 })
 
+  // Context menu state
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
+
+  // Tooltip state
+  const [tooltipState, setTooltipState] = useState<TokenHoverEvent | null>(null)
+
+  // Track container offset for screen coordinate calculations
+  const containerOffsetRef = useRef({ x: 0, y: 0 })
+
   // Track container size with ResizeObserver
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
+
+    const updateOffset = () => {
+      const rect = container.getBoundingClientRect()
+      containerOffsetRef.current = { x: rect.left, y: rect.top }
+    }
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0]
@@ -51,6 +100,7 @@ export function KonvaMap({
           width: entry.contentRect.width,
           height: entry.contentRect.height,
         })
+        updateOffset()
       }
     })
     observer.observe(container)
@@ -60,6 +110,7 @@ export function KonvaMap({
       width: container.clientWidth,
       height: container.clientHeight,
     })
+    updateOffset()
 
     return () => observer.disconnect()
   }, [])
@@ -172,6 +223,113 @@ export function KonvaMap({
     setStagePos({ x: stage.x(), y: stage.y() })
   }, [])
 
+  // Right-click on empty stage area
+  const handleStageContextMenu = useCallback(
+    (e: Konva.KonvaEventObject<PointerEvent>) => {
+      e.evt.preventDefault()
+      if (role !== 'GM') return
+
+      const target = e.target
+      const stage = target.getStage()
+      const isStage = target === stage
+      const isLayer = target.nodeType === 'Layer'
+
+      // Only handle right-click on empty space (stage/layer), not on tokens
+      if (!isStage && !isLayer) return
+
+      const pointer = stage?.getRelativePointerPosition()
+      if (!pointer) return
+
+      setContextMenu({
+        screenX: e.evt.clientX,
+        screenY: e.evt.clientY,
+        tokenId: null,
+        mapX: pointer.x,
+        mapY: pointer.y,
+      })
+    },
+    [role],
+  )
+
+  // Token context menu handler from KonvaTokenLayer
+  const handleTokenContextMenu = useCallback((event: TokenContextMenuEvent) => {
+    setTooltipState(null)
+    setContextMenu({
+      screenX: event.screenX,
+      screenY: event.screenY,
+      tokenId: event.tokenId,
+      mapX: event.mapX,
+      mapY: event.mapY,
+    })
+  }, [])
+
+  // Token hover handler
+  const handleTokenHover = useCallback(
+    (event: TokenHoverEvent | null) => {
+      // Don't show tooltip while context menu is open
+      if (contextMenu) return
+      setTooltipState(event)
+    },
+    [contextMenu],
+  )
+
+  // Close context menu
+  const handleCloseContextMenu = useCallback(() => {
+    setContextMenu(null)
+  }, [])
+
+  // Create token on empty space
+  const handleCreateToken = useCallback(
+    (mapX: number, mapY: number) => {
+      if (!scene) return
+      let x = mapX
+      let y = mapY
+      if (scene.gridSnap) {
+        const snapped = snapToGrid(x, y, scene.gridSize, scene.gridOffsetX, scene.gridOffsetY)
+        x = snapped.x
+        y = snapped.y
+      }
+      const newToken: MapToken = {
+        id: generateTokenId(),
+        x,
+        y,
+        size: 1,
+        color: randomColor(),
+        permissions: { default: 'observer', seats: {} },
+      }
+      onAddToken(newToken)
+    },
+    [scene, onAddToken],
+  )
+
+  // Copy token (create duplicate at offset)
+  const handleCopyToken = useCallback(
+    (token: MapToken) => {
+      if (!scene) return
+      const gridSize = scene.gridSize
+      const newToken: MapToken = {
+        ...token,
+        id: generateTokenId(),
+        x: token.x + gridSize,
+        y: token.y + gridSize,
+      }
+      onAddToken(newToken)
+    },
+    [scene, onAddToken],
+  )
+
+  // Resolve context menu token + entity
+  const contextMenuToken = contextMenu?.tokenId
+    ? (tokens.find((t) => t.id === contextMenu.tokenId) ?? null)
+    : null
+  const contextMenuEntity = contextMenuToken?.entityId ? getEntity(contextMenuToken.entityId) : null
+
+  // Resolve tooltip token + entity
+  const tooltipToken = tooltipState
+    ? (tokens.find((t) => t.id === tooltipState.tokenId) ?? null)
+    : null
+  const tooltipEntity = tooltipToken?.entityId ? getEntity(tooltipToken.entityId) : null
+
   // No scene state
   if (!scene) {
     return (
@@ -219,6 +377,7 @@ export function KonvaMap({
           onClick={handleStageClick}
           onTap={handleStageClick}
           onDragEnd={handleDragEnd}
+          onContextMenu={handleStageContextMenu}
         >
           {/* Background layer — non-interactive */}
           <BackgroundLayer scene={scene} />
@@ -245,8 +404,41 @@ export function KonvaMap({
             onSelectToken={onSelectToken}
             onUpdateToken={onUpdateToken}
             stageScale={stageScale}
+            stagePos={stagePos}
+            containerOffset={containerOffsetRef.current}
+            onTokenContextMenu={handleTokenContextMenu}
+            onTokenHover={handleTokenHover}
           />
         </Stage>
+      )}
+
+      {/* Context menu — HTML overlay */}
+      {contextMenu && (
+        <TokenContextMenu
+          x={contextMenu.screenX}
+          y={contextMenu.screenY}
+          tokenId={contextMenu.tokenId}
+          token={contextMenuToken}
+          entity={contextMenuEntity}
+          role={role}
+          onClose={handleCloseContextMenu}
+          onDeleteToken={onDeleteToken}
+          onUpdateToken={onUpdateToken}
+          onCreateToken={handleCreateToken}
+          onCopyToken={handleCopyToken}
+          mapX={contextMenu.mapX}
+          mapY={contextMenu.mapY}
+        />
+      )}
+
+      {/* Tooltip — HTML overlay */}
+      {tooltipState && tooltipToken && (
+        <TokenTooltip
+          token={tooltipToken}
+          entity={tooltipEntity}
+          screenX={tooltipState.screenX}
+          screenY={tooltipState.screenY}
+        />
       )}
 
       {/* Zoom helper controls — HTML overlay */}
@@ -280,7 +472,9 @@ function BackgroundLayer({ scene }: { scene: Scene }) {
     return <VideoBackground url={imageUrl} width={scene.width} height={scene.height} />
   }
 
-  return <ImageBackground url={imageUrl} width={scene.width} height={scene.height} name={scene.name} />
+  return (
+    <ImageBackground url={imageUrl} width={scene.width} height={scene.height} name={scene.name} />
+  )
 }
 
 function ImageBackground({
@@ -319,15 +513,7 @@ function ImageBackground({
   )
 }
 
-function VideoBackground({
-  url,
-  width,
-  height,
-}: {
-  url: string
-  width: number
-  height: number
-}) {
+function VideoBackground({ url, width, height }: { url: string; width: number; height: number }) {
   const imageRef = useRef<Konva.Image>(null)
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const animRef = useRef<ReturnType<typeof requestAnimationFrame> | null>(null)
@@ -370,14 +556,7 @@ function VideoBackground({
   return (
     <Layer listening={false}>
       {videoRef.current && (
-        <Image
-          ref={imageRef}
-          image={videoRef.current}
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-        />
+        <Image ref={imageRef} image={videoRef.current} x={0} y={0} width={width} height={height} />
       )}
     </Layer>
   )

--- a/src/combat/KonvaToken.tsx
+++ b/src/combat/KonvaToken.tsx
@@ -14,9 +14,12 @@ interface KonvaTokenProps {
   canDrag: boolean
   stageScale: number
   onSelect: (tokenId: string) => void
-  onDragStart: (e: Konva.KonvaEventObject<DragEvent>) => void
-  onDragMove: (e: Konva.KonvaEventObject<DragEvent>) => void
+  onDragStart: (e: Konva.KonvaEventObject<DragEvent>, tokenId: string) => void
+  onDragMove: (e: Konva.KonvaEventObject<DragEvent>, tokenId: string) => void
   onDragEnd: (e: Konva.KonvaEventObject<DragEvent>, tokenId: string) => void
+  onContextMenu?: (e: Konva.KonvaEventObject<PointerEvent>, tokenId: string) => void
+  onMouseEnter?: (e: Konva.KonvaEventObject<MouseEvent>, tokenId: string) => void
+  onMouseLeave?: (e: Konva.KonvaEventObject<MouseEvent>, tokenId: string) => void
 }
 
 export function KonvaToken({
@@ -31,8 +34,10 @@ export function KonvaToken({
   onDragStart,
   onDragMove,
   onDragEnd,
+  onContextMenu,
+  onMouseEnter,
+  onMouseLeave,
 }: KonvaTokenProps) {
-
   const color = entity?.color ?? token.color ?? '#888'
   const imageUrl = entity?.imageUrl ?? token.imageUrl ?? ''
   const name = entity?.name ?? token.label ?? ''
@@ -66,9 +71,16 @@ export function KonvaToken({
         e.cancelBubble = true
         onSelect(token.id)
       }}
-      onDragStart={onDragStart}
-      onDragMove={onDragMove}
+      onDragStart={(e) => onDragStart(e, token.id)}
+      onDragMove={(e) => onDragMove(e, token.id)}
       onDragEnd={(e) => onDragEnd(e, token.id)}
+      onContextMenu={(e) => {
+        e.evt.preventDefault()
+        e.cancelBubble = true
+        onContextMenu?.(e, token.id)
+      }}
+      onMouseEnter={(e) => onMouseEnter?.(e, token.id)}
+      onMouseLeave={(e) => onMouseLeave?.(e, token.id)}
     >
       {/* Clipped circle for the token visual */}
       <Group
@@ -121,13 +133,7 @@ export function KonvaToken({
       />
 
       {/* Overlay group — scaled inversely so it stays constant screen size */}
-      <Group
-        x={radius}
-        y={pixelSize + 2}
-        scaleX={invScale}
-        scaleY={invScale}
-        listening={false}
-      >
+      <Group x={radius} y={pixelSize + 2} scaleX={invScale} scaleY={invScale} listening={false}>
         {/* Name label */}
         {name.length > 0 && (
           <Text
@@ -179,15 +185,13 @@ export function KonvaToken({
             {statuses.slice(0, 3).map((s, i) => {
               const sc = statusColor(s.label)
               const chipWidth = Math.min(s.label.length * 5 + 8, 40)
-              const totalWidth = statuses.slice(0, 3).reduce(
-                (sum, st) => sum + Math.min(st.label.length * 5 + 8, 40) + 2,
-                -2,
-              )
+              const totalWidth = statuses
+                .slice(0, 3)
+                .reduce((sum, st) => sum + Math.min(st.label.length * 5 + 8, 40) + 2, -2)
               const startX = -totalWidth / 2
               let offsetX = startX
               for (let j = 0; j < i; j++) {
-                offsetX +=
-                  Math.min(statuses[j].label.length * 5 + 8, 40) + 2
+                offsetX += Math.min(statuses[j].label.length * 5 + 8, 40) + 2
               }
               return (
                 <Group key={i} x={offsetX} y={0}>
@@ -217,15 +221,12 @@ export function KonvaToken({
             })}
             {statuses.length > 3 && (
               <Group
-                x={
-                  (() => {
-                    const totalWidth = statuses.slice(0, 3).reduce(
-                      (sum, st) => sum + Math.min(st.label.length * 5 + 8, 40) + 2,
-                      -2,
-                    )
-                    return totalWidth / 2 + 4
-                  })()
-                }
+                x={(() => {
+                  const totalWidth = statuses
+                    .slice(0, 3)
+                    .reduce((sum, st) => sum + Math.min(st.label.length * 5 + 8, 40) + 2, -2)
+                  return totalWidth / 2 + 4
+                })()}
                 y={0}
               >
                 <Rect

--- a/src/combat/KonvaTokenLayer.tsx
+++ b/src/combat/KonvaTokenLayer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react'
+import { useRef, useCallback, useState } from 'react'
 import { Layer } from 'react-konva'
 import type Konva from 'konva'
 import type { MapToken as MapTokenType, Entity } from '../shared/entityTypes'
@@ -6,6 +6,21 @@ import type { Scene } from '../stores/worldStore'
 import { getEffectivePermissions, canSee } from '../shared/permissions'
 import { canDragToken, snapToGrid } from './combatUtils'
 import { KonvaToken } from './KonvaToken'
+import { GhostToken } from './GhostToken'
+
+export interface TokenContextMenuEvent {
+  screenX: number
+  screenY: number
+  tokenId: string
+  mapX: number
+  mapY: number
+}
+
+export interface TokenHoverEvent {
+  tokenId: string
+  screenX: number
+  screenY: number
+}
 
 interface KonvaTokenLayerProps {
   tokens: MapTokenType[]
@@ -17,6 +32,10 @@ interface KonvaTokenLayerProps {
   onSelectToken: (id: string | null) => void
   onUpdateToken: (id: string, updates: Partial<MapTokenType>) => void
   stageScale: number
+  stagePos: { x: number; y: number }
+  containerOffset: { x: number; y: number }
+  onTokenContextMenu?: (event: TokenContextMenuEvent) => void
+  onTokenHover?: (event: TokenHoverEvent | null) => void
 }
 
 const DRAG_THRESHOLD = 3
@@ -31,10 +50,24 @@ export function KonvaTokenLayer({
   onSelectToken,
   onUpdateToken,
   stageScale,
+  stagePos,
+  containerOffset,
+  onTokenContextMenu,
+  onTokenHover,
 }: KonvaTokenLayerProps) {
   // Track whether a real drag happened (vs. click)
   const didDragRef = useRef(false)
   const dragStartPosRef = useRef<{ x: number; y: number } | null>(null)
+  const isDraggingRef = useRef(false)
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Ghost token state — snapped position during drag
+  const [ghostState, setGhostState] = useState<{
+    x: number
+    y: number
+    pixelSize: number
+    color: string
+  } | null>(null)
 
   // Filter tokens by visibility
   const visibleTokens = tokens.filter((t) => {
@@ -42,33 +75,79 @@ export function KonvaTokenLayer({
     return canSee(perms, mySeatId, role)
   })
 
+  const clearHoverTimer = useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      clearTimeout(hoverTimerRef.current)
+      hoverTimerRef.current = null
+    }
+  }, [])
+
+  const draggingTokenIdRef = useRef<string | null>(null)
+
   const handleDragStart = useCallback(
-    (e: Konva.KonvaEventObject<DragEvent>) => {
+    (e: Konva.KonvaEventObject<DragEvent>, tokenId: string) => {
       const node = e.target
       didDragRef.current = false
+      isDraggingRef.current = true
+      draggingTokenIdRef.current = tokenId
       dragStartPosRef.current = { x: node.x(), y: node.y() }
+      // Clear tooltip on drag start
+      clearHoverTimer()
+      onTokenHover?.(null)
     },
-    [],
+    [clearHoverTimer, onTokenHover],
   )
 
   const handleDragMove = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>) => {
-      if (didDragRef.current) return
       const startPos = dragStartPosRef.current
       if (!startPos) return
       const node = e.target
       const dx = node.x() - startPos.x
       const dy = node.y() - startPos.y
-      if (Math.abs(dx) + Math.abs(dy) > DRAG_THRESHOLD) {
-        didDragRef.current = true
+
+      if (!didDragRef.current) {
+        if (Math.abs(dx) + Math.abs(dy) > DRAG_THRESHOLD) {
+          didDragRef.current = true
+        } else {
+          return
+        }
+      }
+
+      // Show ghost token at snap position (only when gridSnap is enabled)
+      if (scene.gridSnap && didDragRef.current) {
+        const snapped = snapToGrid(
+          node.x(),
+          node.y(),
+          scene.gridSize,
+          scene.gridOffsetX,
+          scene.gridOffsetY,
+        )
+        const draggedToken = draggingTokenIdRef.current
+          ? tokens.find((t) => t.id === draggingTokenIdRef.current)
+          : null
+        const entity = draggedToken?.entityId ? getEntity(draggedToken.entityId) : null
+        const tokenSize = draggedToken?.size ?? 1
+        const tokenColor = entity?.color ?? draggedToken?.color ?? '#888'
+
+        setGhostState({
+          x: snapped.x,
+          y: snapped.y,
+          pixelSize: tokenSize * scene.gridSize,
+          color: tokenColor,
+        })
       }
     },
-    [],
+    [scene.gridSnap, scene.gridSize, scene.gridOffsetX, scene.gridOffsetY, tokens, getEntity],
   )
 
   const handleDragEnd = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>, tokenId: string) => {
       const node = e.target
+      isDraggingRef.current = false
+      draggingTokenIdRef.current = null
+      setGhostState(null)
+
       if (didDragRef.current) {
         let finalX = node.x()
         let finalY = node.y()
@@ -109,8 +188,64 @@ export function KonvaTokenLayer({
     [selectedTokenId, onSelectToken],
   )
 
+  const handleContextMenu = useCallback(
+    (e: Konva.KonvaEventObject<PointerEvent>, tokenId: string) => {
+      if (!onTokenContextMenu) return
+      const token = tokens.find((t) => t.id === tokenId)
+      if (!token) return
+
+      const pixelSize = token.size * scene.gridSize
+      const screenX = (token.x + pixelSize / 2) * stageScale + stagePos.x + containerOffset.x
+      const screenY = token.y * stageScale + stagePos.y + containerOffset.y
+
+      onTokenContextMenu({
+        screenX: e.evt.clientX,
+        screenY: e.evt.clientY,
+        tokenId,
+        mapX: screenX,
+        mapY: screenY,
+      })
+    },
+    [onTokenContextMenu, tokens, scene.gridSize, stageScale, stagePos, containerOffset],
+  )
+
+  const handleMouseEnter = useCallback(
+    (_e: Konva.KonvaEventObject<MouseEvent>, tokenId: string) => {
+      if (isDraggingRef.current) return
+      clearHoverTimer()
+
+      hoverTimerRef.current = setTimeout(() => {
+        if (isDraggingRef.current) return
+        const token = tokens.find((t) => t.id === tokenId)
+        if (!token) return
+
+        const pixelSize = token.size * scene.gridSize
+        const screenX = (token.x + pixelSize / 2) * stageScale + stagePos.x + containerOffset.x
+        const screenY = (token.y + pixelSize) * stageScale + stagePos.y + containerOffset.y
+
+        onTokenHover?.({ tokenId, screenX, screenY })
+      }, 300)
+    },
+    [tokens, scene.gridSize, stageScale, stagePos, containerOffset, onTokenHover, clearHoverTimer],
+  )
+
+  const handleMouseLeave = useCallback(() => {
+    clearHoverTimer()
+    onTokenHover?.(null)
+  }, [clearHoverTimer, onTokenHover])
+
   return (
     <Layer>
+      {/* Ghost token preview (shown during drag with grid snap) */}
+      {ghostState && (
+        <GhostToken
+          x={ghostState.x}
+          y={ghostState.y}
+          pixelSize={ghostState.pixelSize}
+          color={ghostState.color}
+        />
+      )}
+
       {visibleTokens.map((token) => {
         const entity = token.entityId ? getEntity(token.entityId) : null
         const isHidden =
@@ -131,6 +266,9 @@ export function KonvaTokenLayer({
             onDragStart={handleDragStart}
             onDragMove={handleDragMove}
             onDragEnd={handleDragEnd}
+            onContextMenu={handleContextMenu}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
           />
         )
       })}

--- a/src/combat/TacticalPanel.tsx
+++ b/src/combat/TacticalPanel.tsx
@@ -12,6 +12,8 @@ interface TacticalPanelProps {
   selectedTokenId: string | null
   onSelectToken: (id: string | null) => void
   onUpdateToken: (id: string, updates: Partial<MapToken>) => void
+  onDeleteToken: (id: string) => void
+  onAddToken: (token: MapToken) => void
   onContextMenu?: (e: React.MouseEvent) => void
   onClose: () => void
 }
@@ -25,6 +27,8 @@ export function TacticalPanel({
   selectedTokenId,
   onSelectToken,
   onUpdateToken,
+  onDeleteToken,
+  onAddToken,
   onContextMenu,
   onClose,
 }: TacticalPanelProps) {
@@ -66,6 +70,8 @@ export function TacticalPanel({
           selectedTokenId={selectedTokenId}
           onSelectToken={onSelectToken}
           onUpdateToken={onUpdateToken}
+          onDeleteToken={onDeleteToken}
+          onAddToken={onAddToken}
         />
       </div>
     </div>

--- a/src/combat/TokenContextMenu.tsx
+++ b/src/combat/TokenContextMenu.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef } from 'react'
+import type { MapToken, Entity } from '../shared/entityTypes'
+
+interface TokenContextMenuProps {
+  x: number
+  y: number
+  tokenId: string | null
+  token: MapToken | null
+  entity: Entity | null
+  role: 'GM' | 'PL'
+  onClose: () => void
+  onDeleteToken: (id: string) => void
+  onUpdateToken: (id: string, updates: Partial<MapToken>) => void
+  onCreateToken: (x: number, y: number) => void
+  onCopyToken: (token: MapToken) => void
+  mapX: number
+  mapY: number
+}
+
+const SIZE_OPTIONS = [1, 2, 3, 4] as const
+
+export function TokenContextMenu({
+  x,
+  y,
+  tokenId,
+  token,
+  entity,
+  role,
+  onClose,
+  onDeleteToken,
+  onUpdateToken,
+  onCreateToken,
+  onCopyToken,
+  mapX,
+  mapY,
+}: TokenContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Click-outside-to-close
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [onClose])
+
+  // Escape key to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  // PL: don't show context menu
+  if (role !== 'GM') return null
+
+  const isTokenMenu = tokenId !== null && token !== null
+  const isHidden = token
+    ? (entity?.permissions.default ?? token.permissions.default) === 'none'
+    : false
+  const currentSize = token?.size ?? 1
+  const tokenName = entity?.name ?? token?.label ?? 'Token'
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-popover bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)] py-1 min-w-[160px] font-sans"
+      style={{ left: x, top: y }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {isTokenMenu ? (
+        <>
+          {/* Header: token name */}
+          <div
+            className="px-3 py-1.5 text-text-muted text-xs font-medium border-b border-border-glass mb-1"
+            style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+          >
+            {tokenName}
+          </div>
+
+          {/* Copy Token */}
+          <MenuItem
+            label="Copy Token"
+            onClick={() => {
+              if (token) onCopyToken(token)
+              onClose()
+            }}
+          />
+
+          {/* Separator */}
+          <div className="border-t border-border-glass my-1" />
+
+          {/* Size submenu — radio style */}
+          <div className="px-3 py-1 text-text-muted" style={{ fontSize: 10, fontWeight: 600 }}>
+            Size
+          </div>
+          <div className="flex gap-1 px-3 py-1">
+            {SIZE_OPTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => {
+                  onUpdateToken(tokenId, { size: s })
+                  onClose()
+                }}
+                className="border-none cursor-pointer rounded text-xs font-bold transition-colors duration-100"
+                style={{
+                  width: 28,
+                  height: 24,
+                  background: s === currentSize ? 'rgba(212,160,85,0.3)' : 'transparent',
+                  color: s === currentSize ? '#D4A055' : '#F0E6D8',
+                  border:
+                    s === currentSize ? '1px solid rgba(212,160,85,0.5)' : '1px solid transparent',
+                }}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+
+          {/* Separator */}
+          <div className="border-t border-border-glass my-1" />
+
+          {/* Visibility toggle */}
+          <MenuItem
+            label={isHidden ? 'Show Token' : 'Hide Token'}
+            onClick={() => {
+              const newDefault = isHidden ? 'observer' : 'none'
+              onUpdateToken(tokenId, {
+                permissions: {
+                  ...token.permissions,
+                  default: newDefault,
+                },
+              })
+              onClose()
+            }}
+          />
+
+          {/* Separator */}
+          <div className="border-t border-border-glass my-1" />
+
+          {/* Delete Token */}
+          <MenuItem
+            label="Delete Token"
+            danger
+            onClick={() => {
+              onDeleteToken(tokenId)
+              onClose()
+            }}
+          />
+        </>
+      ) : (
+        /* Empty space menu */
+        <MenuItem
+          label="Create Token"
+          onClick={() => {
+            onCreateToken(mapX, mapY)
+            onClose()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── MenuItem helper ──
+
+function MenuItem({
+  label,
+  onClick,
+  danger,
+}: {
+  label: string
+  onClick: () => void
+  danger?: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="block w-full px-3 py-1.5 bg-transparent border-none text-xs font-medium text-left font-sans transition-colors duration-100 cursor-pointer hover:bg-hover"
+      style={{
+        color: danger ? '#C04040' : '#F0E6D8',
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/src/combat/TokenTooltip.tsx
+++ b/src/combat/TokenTooltip.tsx
@@ -1,0 +1,123 @@
+import type { MapToken, Entity } from '../shared/entityTypes'
+import { getEntityResources, getEntityStatuses } from '../shared/entityAdapters'
+import { statusColor } from '../shared/tokenUtils'
+
+interface TokenTooltipProps {
+  token: MapToken
+  entity: Entity | null
+  screenX: number
+  screenY: number
+}
+
+export function TokenTooltip({ token, entity, screenX, screenY }: TokenTooltipProps) {
+  const name = entity?.name ?? token.label ?? ''
+  const resources = getEntityResources(entity)
+  const mainResource = resources[0]
+  const hasHp = mainResource !== undefined && mainResource.max > 0
+  const hpPct = hasHp ? Math.min(mainResource.current / mainResource.max, 1) : 0
+
+  const statuses = getEntityStatuses(entity)
+  const visibleStatuses = statuses.slice(0, 3)
+  const extraCount = statuses.length - 3
+
+  // Nothing to show
+  if (!name && !hasHp && statuses.length === 0) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: screenX,
+        top: screenY + 8,
+        transform: 'translateX(-50%)',
+        pointerEvents: 'none',
+        zIndex: 10002,
+        animation: 'fade-in 150ms ease-out',
+      }}
+      className="bg-glass backdrop-blur-[12px] rounded-md border border-border-glass shadow-[0_4px_16px_rgba(0,0,0,0.5)] px-2.5 py-1.5"
+    >
+      {/* Name */}
+      {name && (
+        <div
+          className="text-text-primary font-bold text-center"
+          style={{ fontSize: 11, lineHeight: '14px', whiteSpace: 'nowrap' }}
+        >
+          {name}
+        </div>
+      )}
+
+      {/* HP bar */}
+      {hasHp && (
+        <div
+          style={{
+            width: 48,
+            height: 5,
+            borderRadius: 3,
+            background: 'rgba(0,0,0,0.5)',
+            marginTop: 3,
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: `${hpPct * 100}%`,
+              height: '100%',
+              borderRadius: 3,
+              background: hpPct > 0.5 ? '#22c55e' : hpPct > 0.25 ? '#f59e0b' : '#ef4444',
+            }}
+          />
+        </div>
+      )}
+
+      {/* Status chips */}
+      {visibleStatuses.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 2,
+            marginTop: 3,
+            justifyContent: 'center',
+            flexWrap: 'nowrap',
+          }}
+        >
+          {visibleStatuses.map((s, i) => (
+            <span
+              key={i}
+              style={{
+                fontSize: 8,
+                fontWeight: 700,
+                color: '#fff',
+                background: `${statusColor(s.label)}cc`,
+                borderRadius: 4,
+                padding: '1px 4px',
+                whiteSpace: 'nowrap',
+                maxWidth: 40,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {s.label}
+            </span>
+          ))}
+          {extraCount > 0 && (
+            <span
+              style={{
+                fontSize: 8,
+                fontWeight: 700,
+                color: '#fff',
+                background: 'rgba(255,255,255,0.2)',
+                borderRadius: 4,
+                padding: '1px 4px',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              +{extraCount}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **TokenContextMenu**: GM-only right-click menu on tokens (copy, resize 1-4, hide/show, delete) and empty space (create token)
- **TokenTooltip**: 300ms hover delay tooltip showing name, HP mini-bar (color-coded), and status chips (max 3 + overflow)
- **GhostToken**: Semi-transparent dashed-border snap preview during grid-snap drag, matching token size and color
- Wires new interactions through KonvaTokenLayer → KonvaMap → TacticalPanel → App

## Test plan
- [ ] Right-click a token to see context menu (GM only, PL should see nothing)
- [ ] Test copy/size/visibility/delete from context menu
- [ ] Right-click empty space to see "Create Token" option
- [ ] Hover a token for 300ms to see tooltip with name and HP bar
- [ ] Drag a token with grid snap enabled to see ghost preview at snap position
- [ ] Verify ghost token matches dragged token's color and size
- [ ] Verify tooltip dismisses on drag and context menu open