### PR TITLE
feat: add initiative tracking system with drag-to-reorder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,8 @@ function RoomSession({ roomId }: { roomId: string }) {
   const removeEntityFromScene = useWorldStore((s) => s.removeEntityFromScene)
   const getSceneEntityIds = useWorldStore((s) => s.getSceneEntityIds)
   const setCombatActive = useWorldStore((s) => s.setCombatActive)
+  const setInitiativeOrder = useWorldStore((s) => s.setInitiativeOrder)
+  const advanceInitiative = useWorldStore((s) => s.advanceInitiative)
   const addEntity = useWorldStore((s) => s.addEntity)
   const updateEntity = useWorldStore((s) => s.updateEntity)
   const addToken = useWorldStore((s) => s.addToken)
@@ -300,6 +302,14 @@ function RoomSession({ roomId }: { roomId: string }) {
         onSetActiveCharacter={handleSetActiveCharacter}
         onRemoveFromScene={handleRemoveFromScene}
         onUpdateEntity={handleUpdateEntity}
+        isCombat={isCombat}
+        activeScene={activeScene}
+        onSetInitiativeOrder={(order) => {
+          if (room.activeSceneId) setInitiativeOrder(room.activeSceneId, order)
+        }}
+        onAdvanceInitiative={() => {
+          if (room.activeSceneId) advanceInitiative(room.activeSceneId)
+        }}
       />
 
       {/* Top-right: Team dashboard */}

--- a/src/dock/MapDockTab.tsx
+++ b/src/dock/MapDockTab.tsx
@@ -49,6 +49,8 @@ export function MapDockTab({
         sortOrder: scenes.length,
         combatActive: false,
         battleMapUrl: '',
+        initiativeOrder: [],
+        initiativeIndex: 0,
       }
       onAddScene(scene)
       onSelectScene(scene.id)

--- a/src/gm/SceneLibrary.tsx
+++ b/src/gm/SceneLibrary.tsx
@@ -56,6 +56,8 @@ export function SceneLibrary({
           sortOrder: scenes.length,
           combatActive: false,
           battleMapUrl: '',
+          initiativeOrder: [],
+          initiativeIndex: 0,
         }
         onAdd(scene)
       }

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { Users } from 'lucide-react'
+import { Users, ChevronRight } from 'lucide-react'
 import type { Entity } from '../shared/entityTypes'
+import type { Scene } from '../stores/worldStore'
 import { canSee, canEdit } from '../shared/permissions'
 import { getEntityResources, getEntityStatuses } from '../shared/entityAdapters'
 import { statusColor } from '../shared/tokenUtils'
@@ -25,6 +26,10 @@ interface PortraitBarProps {
   onSetActiveCharacter: (charId: string) => void
   onRemoveFromScene: (entityId: string) => void
   onUpdateEntity: (id: string, updates: Partial<Entity>) => void
+  isCombat: boolean
+  activeScene: Scene | null
+  onSetInitiativeOrder: (order: string[]) => void
+  onAdvanceInitiative: () => void
 }
 
 const PORTRAIT_SIZE = 52
@@ -91,11 +96,24 @@ export function PortraitBar({
   onSetActiveCharacter,
   onRemoveFromScene,
   onUpdateEntity,
+  isCombat,
+  activeScene,
+  onSetInitiativeOrder,
+  onAdvanceInitiative,
 }: PortraitBarProps) {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; entityId: string } | null>(
     null,
   )
   const [activeTab, setActiveTab] = useState<PortraitTabId>('characters')
+
+  // Auto-switch to initiative tab when combat starts
+  useEffect(() => {
+    if (isCombat) setActiveTab('initiative')
+    else setActiveTab('characters')
+  }, [isCombat])
+
+  // Drag state for initiative reorder
+  const [draggedEntityId, setDraggedEntityId] = useState<string | null>(null)
 
   // Hover state
   const [hoveredCharId, setHoveredCharId] = useState<string | null>(null)
@@ -443,11 +461,105 @@ export function PortraitBar({
         </div>
       )}
 
-      {activeTab === 'initiative' && (
-        <div className="flex items-center justify-center px-5 py-2 bg-glass backdrop-blur-[16px] rounded-[28px] border border-border-glass shadow-[0_4px_20px_rgba(0,0,0,0.25)] text-xs text-text-muted/40 font-sans pointer-events-auto">
-          Coming soon
-        </div>
-      )}
+      {activeTab === 'initiative' &&
+        (() => {
+          const initiativeOrder = activeScene?.initiativeOrder ?? []
+          const initiativeIndex = activeScene?.initiativeIndex ?? 0
+
+          // If no initiative order set, show setup button (GM) or empty state
+          if (initiativeOrder.length === 0) {
+            const handleInitSetup = () => {
+              const ids = visibleEntities.map((e) => e.id)
+              if (ids.length > 0) onSetInitiativeOrder(ids)
+            }
+            return (
+              <div className="flex items-center gap-2 bg-glass backdrop-blur-[16px] rounded-[28px] px-2.5 py-[5px] shadow-[0_4px_20px_rgba(0,0,0,0.25)] border border-border-glass pointer-events-auto">
+                {isGM ? (
+                  <button
+                    onClick={handleInitSetup}
+                    className="px-3 py-1 text-[11px] font-semibold font-sans text-accent bg-transparent border border-accent/30 rounded-full cursor-pointer transition-colors duration-fast hover:bg-accent/10"
+                  >
+                    Set Initiative Order
+                  </button>
+                ) : (
+                  <span className="text-xs text-text-muted/40 font-sans px-3 py-1">
+                    No initiative order
+                  </span>
+                )}
+              </div>
+            )
+          }
+
+          // Resolve entities in initiative order
+          const orderedEntities = initiativeOrder
+            .map((id) => visibleEntities.find((e) => e.id === id))
+            .filter((e): e is Entity => !!e)
+
+          if (orderedEntities.length === 0) return null
+
+          const currentTurnId = initiativeOrder[initiativeIndex % initiativeOrder.length]
+
+          return (
+            <div className="flex gap-1.5 items-center bg-glass backdrop-blur-[16px] rounded-[28px] px-2.5 py-[5px] shadow-[0_4px_20px_rgba(0,0,0,0.25)] border border-border-glass pointer-events-auto">
+              {orderedEntities.map((entity) => {
+                const isCurrent = entity.id === currentTurnId
+                return (
+                  <div
+                    key={entity.id}
+                    draggable={isGM}
+                    onDragStart={(e) => {
+                      e.dataTransfer.setData('text/plain', entity.id)
+                      setDraggedEntityId(entity.id)
+                    }}
+                    onDragEnd={() => setDraggedEntityId(null)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={(e) => {
+                      e.preventDefault()
+                      const fromId = e.dataTransfer.getData('text/plain')
+                      if (!fromId || fromId === entity.id) return
+                      const newOrder = [...initiativeOrder]
+                      const fromIdx = newOrder.indexOf(fromId)
+                      const toIdx = newOrder.indexOf(entity.id)
+                      if (fromIdx === -1 || toIdx === -1) return
+                      newOrder.splice(fromIdx, 1)
+                      newOrder.splice(toIdx, 0, fromId)
+                      onSetInitiativeOrder(newOrder)
+                      setDraggedEntityId(null)
+                    }}
+                    style={{
+                      opacity: draggedEntityId === entity.id ? 0.4 : 1,
+                      border: isCurrent ? '2px solid #D4A055' : '2px solid transparent',
+                      boxShadow: isCurrent ? '0 0 10px rgba(212,160,85,0.4)' : 'none',
+                      borderRadius: '50%',
+                      cursor: isGM ? 'grab' : 'pointer',
+                      transition: 'opacity 0.15s, border-color 0.2s, box-shadow 0.2s',
+                    }}
+                    onClick={(e) => handlePortraitClick(entity.id, e.currentTarget as HTMLElement)}
+                    onContextMenu={(e) => handleContextMenu(e, entity.id)}
+                    onMouseEnter={(e) =>
+                      handlePortraitMouseEnter(entity.id, e.currentTarget as HTMLElement)
+                    }
+                    onMouseLeave={() => handlePortraitMouseLeave()}
+                  >
+                    {renderPortrait(entity)}
+                  </div>
+                )
+              })}
+
+              {/* Next Turn button (GM only) */}
+              {isGM && (
+                <button
+                  onClick={onAdvanceInitiative}
+                  className="flex items-center justify-center rounded-full bg-accent text-deep cursor-pointer border-none transition-transform duration-fast hover:scale-110"
+                  style={{ width: 28, height: 28, flexShrink: 0 }}
+                  title="Next Turn"
+                >
+                  <ChevronRight size={16} strokeWidth={2.5} />
+                </button>
+              )}
+            </div>
+          )
+        })()}
 
       {/* Context menu — rendered via portal to avoid transform offset */}
       {contextMenu &&

--- a/src/stores/worldStore.ts
+++ b/src/stores/worldStore.ts
@@ -27,6 +27,8 @@ export interface Scene {
   sortOrder: number
   combatActive: boolean
   battleMapUrl: string
+  initiativeOrder: string[]
+  initiativeIndex: number
 }
 
 export interface RoomState {
@@ -122,6 +124,8 @@ function readScenes(yScenes: Y.Map<Y.Map<unknown>>): Scene[] {
       sortOrder: (sceneMap.get('sortOrder') as number) ?? 0,
       combatActive: (sceneMap.get('combatActive') as boolean) ?? false,
       battleMapUrl: (sceneMap.get('battleMapUrl') as string) ?? '',
+      initiativeOrder: (sceneMap.get('initiativeOrder') as string[]) ?? [],
+      initiativeIndex: (sceneMap.get('initiativeIndex') as number) ?? 0,
     })
   })
   scenes.sort((a, b) => a.sortOrder - b.sortOrder)
@@ -300,6 +304,8 @@ interface WorldState {
   removeEntityFromScene: (sceneId: string, entityId: string) => void
   getSceneEntityIds: (sceneId: string) => string[]
   setCombatActive: (sceneId: string, active: boolean) => void
+  setInitiativeOrder: (sceneId: string, order: string[]) => void
+  advanceInitiative: (sceneId: string) => void
 
   // Entity actions
   addEntity: (entity: Entity) => void
@@ -557,6 +563,25 @@ export const useWorldStore = create<WorldState>((set, get) => ({
     const sceneMap = yScenes.get(sceneId)
     if (!(sceneMap instanceof Y.Map)) return
     sceneMap.set('combatActive', active)
+  },
+
+  setInitiativeOrder: (sceneId: string, order: string[]) => {
+    const yScenes = get()._yScenes
+    if (!yScenes) return
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    sceneMap.set('initiativeOrder', order)
+  },
+
+  advanceInitiative: (sceneId: string) => {
+    const yScenes = get()._yScenes
+    if (!yScenes) return
+    const sceneMap = yScenes.get(sceneId)
+    if (!(sceneMap instanceof Y.Map)) return
+    const order = (sceneMap.get('initiativeOrder') as string[]) ?? []
+    if (order.length === 0) return
+    const current = (sceneMap.get('initiativeIndex') as number) ?? 0
+    sceneMap.set('initiativeIndex', (current + 1) % order.length)
   },
 
   // ── Entity actions ──

--- a/src/yjs/__tests__/useScenes.sync.test.ts
+++ b/src/yjs/__tests__/useScenes.sync.test.ts
@@ -20,6 +20,8 @@ const baseScene: Scene = {
   sortOrder: 0,
   combatActive: false,
   battleMapUrl: '',
+  initiativeOrder: [],
+  initiativeIndex: 0,
 }
 
 describe('useScenes — multi-client sync', () => {

--- a/src/yjs/__tests__/useScenes.test.ts
+++ b/src/yjs/__tests__/useScenes.test.ts
@@ -21,6 +21,8 @@ function makeScene(overrides?: Partial<Scene>): Scene {
     sortOrder: 0,
     combatActive: false,
     battleMapUrl: '',
+    initiativeOrder: [],
+    initiativeIndex: 0,
     ...overrides,
   }
 }

--- a/src/yjs/useScenes.ts
+++ b/src/yjs/useScenes.ts
@@ -18,6 +18,8 @@ export interface Scene {
   sortOrder: number
   combatActive: boolean
   battleMapUrl: string
+  initiativeOrder: string[]
+  initiativeIndex: number
 }
 
 function readScenes(yScenes: Y.Map<Y.Map<unknown>>): Scene[] {
@@ -44,6 +46,8 @@ function readScenes(yScenes: Y.Map<Y.Map<unknown>>): Scene[] {
       sortOrder: (sceneMap.get('sortOrder') as number) ?? 0,
       combatActive: (sceneMap.get('combatActive') as boolean) ?? false,
       battleMapUrl: (sceneMap.get('battleMapUrl') as string) ?? '',
+      initiativeOrder: (sceneMap.get('initiativeOrder') as string[]) ?? [],
+      initiativeIndex: (sceneMap.get('initiativeIndex') as number) ?? 0,
     })
   })
   scenes.sort((a, b) => a.sortOrder - b.sortOrder)
@@ -131,6 +135,8 @@ export function useScenes(yScenes: Y.Map<Y.Map<unknown>>, yDoc: Y.Doc) {
       sortOrder: (sceneMap.get('sortOrder') as number) ?? 0,
       combatActive: (sceneMap.get('combatActive') as boolean) ?? false,
       battleMapUrl: (sceneMap.get('battleMapUrl') as string) ?? '',
+      initiativeOrder: (sceneMap.get('initiativeOrder') as string[]) ?? [],
+      initiativeIndex: (sceneMap.get('initiativeIndex') as number) ?? 0,
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `initiativeOrder` and `initiativeIndex` fields to Scene data model (Yjs-synced)
- Replace "Coming soon" initiative tab in PortraitBar with functional initiative tracker
- GM can drag-to-reorder portraits, advance turns with "Next Turn" button
- Auto-switches to initiative tab when combat starts

## Test plan
- [ ] Enter combat mode → initiative tab auto-activates
- [ ] Click "Set Initiative Order" to populate from visible entities
- [ ] Verify current turn entity has golden ring highlight
- [ ] Click "Next Turn" to advance (wraps around at end)
- [ ] GM: drag portraits to reorder initiative
- [ ] PL: cannot drag, sees order set by GM
- [ ] Multi-client: initiative order and turn syncs via Yjs
- [ ] Exit combat → switches back to characters tab