### PR TITLE
feat: add portrait drag-to-map token placement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { MyCharacterCard } from './layout/MyCharacterCard'
 import { ContextMenu } from './shared/ContextMenu'
 import { ShowcaseOverlay } from './showcase/ShowcaseOverlay'
 import type { ShowcaseItem } from './showcase/showcaseTypes'
-import type { Entity } from './shared/entityTypes'
+import type { Entity, MapToken } from './shared/entityTypes'
 import { defaultNPCPermissions } from './shared/permissions'
 import {
   gcOrphanedEntities,
@@ -262,6 +262,24 @@ function RoomSession({ roomId }: { roomId: string }) {
     setBgContextMenu(null)
   }
 
+  const handleDropEntityOnMap = (entityId: string, mapX: number, mapY: number) => {
+    const entity = getEntity(entityId)
+    if (!entity) return
+    const newToken: MapToken = {
+      id: generateTokenId(),
+      entityId: entity.id,
+      x: mapX,
+      y: mapY,
+      size: entity.size || 1,
+      color: entity.color,
+      imageUrl: entity.imageUrl,
+      label: entity.name,
+      permissions: { default: entity.permissions.default, seats: { ...entity.permissions.seats } },
+    }
+    addToken(newToken)
+    setSelectedTokenId(newToken.id)
+  }
+
   return (
     <div>
       <SceneViewer scene={activeScene} onContextMenu={handleBgContextMenu} />
@@ -278,6 +296,7 @@ function RoomSession({ roomId }: { roomId: string }) {
           onUpdateToken={updateToken}
           onDeleteToken={deleteToken}
           onAddToken={addToken}
+          onDropEntityOnMap={handleDropEntityOnMap}
           onContextMenu={handleBgContextMenu}
           onClose={() => {
             if (room.activeSceneId) setCombatActive(room.activeSceneId, false)

--- a/src/combat/KonvaMap.tsx
+++ b/src/combat/KonvaMap.tsx
@@ -50,6 +50,7 @@ interface KonvaMapProps {
   onUpdateToken: (id: string, updates: Partial<MapToken>) => void
   onDeleteToken: (id: string) => void
   onAddToken: (token: MapToken) => void
+  onDropEntityOnMap?: (entityId: string, mapX: number, mapY: number) => void
 }
 
 const MIN_SCALE = 0.1
@@ -67,6 +68,7 @@ export function KonvaMap({
   onUpdateToken,
   onDeleteToken,
   onAddToken,
+  onDropEntityOnMap,
 }: KonvaMapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const stageRef = useRef<Konva.Stage>(null)
@@ -361,6 +363,42 @@ export function KonvaMap({
         overflow: 'hidden',
         background: '#111',
         position: 'relative',
+      }}
+      onDragOver={(e) => {
+        if (e.dataTransfer.types.includes('application/x-entity-id')) {
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'copy'
+        }
+      }}
+      onDrop={(e) => {
+        e.preventDefault()
+        const entityId = e.dataTransfer.getData('application/x-entity-id')
+        if (!entityId || !onDropEntityOnMap) return
+
+        // Convert screen coordinates to map coordinates
+        const container = containerRef.current
+        if (!container) return
+        const rect = container.getBoundingClientRect()
+        const screenX = e.clientX - rect.left
+        const screenY = e.clientY - rect.top
+        // Inverse of stage transform: mapCoord = (screenCoord - stagePos) / stageScale
+        let mapX = (screenX - stagePos.x) / stageScale
+        let mapY = (screenY - stagePos.y) / stageScale
+
+        // Grid snap
+        if (scene?.gridSnap) {
+          const snapped = snapToGrid(
+            mapX,
+            mapY,
+            scene.gridSize,
+            scene.gridOffsetX,
+            scene.gridOffsetY,
+          )
+          mapX = snapped.x
+          mapY = snapped.y
+        }
+
+        onDropEntityOnMap(entityId, mapX, mapY)
       }}
     >
       {containerSize.width > 0 && containerSize.height > 0 && (

--- a/src/combat/TacticalPanel.tsx
+++ b/src/combat/TacticalPanel.tsx
@@ -14,6 +14,7 @@ interface TacticalPanelProps {
   onUpdateToken: (id: string, updates: Partial<MapToken>) => void
   onDeleteToken: (id: string) => void
   onAddToken: (token: MapToken) => void
+  onDropEntityOnMap?: (entityId: string, mapX: number, mapY: number) => void
   onContextMenu?: (e: React.MouseEvent) => void
   onClose: () => void
 }
@@ -29,6 +30,7 @@ export function TacticalPanel({
   onUpdateToken,
   onDeleteToken,
   onAddToken,
+  onDropEntityOnMap,
   onContextMenu,
   onClose,
 }: TacticalPanelProps) {
@@ -72,6 +74,7 @@ export function TacticalPanel({
           onUpdateToken={onUpdateToken}
           onDeleteToken={onDeleteToken}
           onAddToken={onAddToken}
+          onDropEntityOnMap={onDropEntityOnMap}
         />
       </div>
     </div>

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -271,6 +271,11 @@ export function PortraitBar({
       <div
         key={entity.id}
         data-char-id={entity.id}
+        draggable={isGM}
+        onDragStart={(e) => {
+          e.dataTransfer.setData('application/x-entity-id', entity.id)
+          e.dataTransfer.effectAllowed = 'copy'
+        }}
         className="relative cursor-pointer transition-transform duration-fast"
         onClick={(e) => {
           handlePortraitClick(entity.id, e.currentTarget as HTMLElement)


### PR DESCRIPTION
## Summary
- GM can drag portraits from the PortraitBar onto the tactical map to create entity-linked tokens
- KonvaMap container handles HTML drag/drop with screen-to-map coordinate conversion and grid snapping
- TacticalPanel passes `onDropEntityOnMap` through to KonvaMap
- App.tsx creates linked MapToken with entity properties (size, color, imageUrl, permissions)

## Test Plan
- [ ] Enter combat mode, drag a portrait from the bar onto the tactical map
- [ ] Verify token appears at the drop location with correct entity data
- [ ] Verify grid snapping works when dropping
- [ ] Verify only GM can drag portraits (players cannot)
- [ ] All 213 tests pass, 0 TypeScript errors