### PR TITLE
feat: add tactical map tools — toolbar, measurement, range templates, grid config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,6 +301,10 @@ function RoomSession({ roomId }: { roomId: string }) {
           onClose={() => {
             if (room.activeSceneId) setCombatActive(room.activeSceneId, false)
           }}
+          onAdvanceInitiative={() => {
+            if (room.activeSceneId) advanceInitiative(room.activeSceneId)
+          }}
+          onUpdateScene={updateScene}
         />
       )}
 

--- a/src/combat/KonvaMap.tsx
+++ b/src/combat/KonvaMap.tsx
@@ -4,11 +4,14 @@ import type Konva from 'konva'
 import type { MapToken, Entity } from '../shared/entityTypes'
 import type { Scene } from '../stores/worldStore'
 import { isVideoUrl } from '../shared/assetUpload'
+import { useUiStore } from '../stores/uiStore'
 import { KonvaGrid } from './KonvaGrid'
 import { KonvaTokenLayer } from './KonvaTokenLayer'
 import type { TokenContextMenuEvent, TokenHoverEvent } from './KonvaTokenLayer'
 import { TokenContextMenu } from './TokenContextMenu'
 import { TokenTooltip } from './TokenTooltip'
+import { MeasureTool } from './tools/MeasureTool'
+import { RangeTemplate } from './tools/RangeTemplate'
 import { useImage } from './useImage'
 import { generateTokenId } from '../shared/idUtils'
 import { snapToGrid } from './combatUtils'
@@ -75,6 +78,10 @@ export function KonvaMap({
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
   const [stageScale, setStageScale] = useState(1)
   const [stagePos, setStagePos] = useState({ x: 0, y: 0 })
+
+  // Active tool from UI store
+  const activeTool = useUiStore((s) => s.activeTool)
+  const isSelectMode = activeTool === 'select'
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
@@ -410,7 +417,7 @@ export function KonvaMap({
           scaleY={stageScale}
           x={stagePos.x}
           y={stagePos.y}
-          draggable
+          draggable={isSelectMode}
           onWheel={handleWheel}
           onClick={handleStageClick}
           onTap={handleStageClick}
@@ -446,6 +453,20 @@ export function KonvaMap({
             containerOffset={containerOffsetRef.current}
             onTokenContextMenu={handleTokenContextMenu}
             onTokenHover={handleTokenHover}
+          />
+
+          {/* Measurement tool layer — above tokens */}
+          <MeasureTool
+            active={activeTool === 'measure'}
+            scene={scene}
+            stageRef={stageRef}
+          />
+
+          {/* Range template layer — above tokens */}
+          <RangeTemplate
+            activeTool={activeTool}
+            scene={scene}
+            stageRef={stageRef}
           />
         </Stage>
       )}

--- a/src/combat/TacticalPanel.tsx
+++ b/src/combat/TacticalPanel.tsx
@@ -1,7 +1,9 @@
-import { X } from 'lucide-react'
+import { useState, useCallback } from 'react'
 import type { Scene } from '../stores/worldStore'
 import type { MapToken, Entity } from '../shared/entityTypes'
 import { KonvaMap } from './KonvaMap'
+import { TacticalToolbar } from './TacticalToolbar'
+import { GridConfigPanel } from './tools/GridConfigPanel'
 
 interface TacticalPanelProps {
   scene: Scene | null
@@ -17,6 +19,8 @@ interface TacticalPanelProps {
   onDropEntityOnMap?: (entityId: string, mapX: number, mapY: number) => void
   onContextMenu?: (e: React.MouseEvent) => void
   onClose: () => void
+  onAdvanceInitiative: () => void
+  onUpdateScene: (sceneId: string, updates: Partial<Scene>) => void
 }
 
 export function TacticalPanel({
@@ -33,7 +37,24 @@ export function TacticalPanel({
   onDropEntityOnMap,
   onContextMenu,
   onClose,
+  onAdvanceInitiative,
+  onUpdateScene,
 }: TacticalPanelProps) {
+  const [showGridConfig, setShowGridConfig] = useState(false)
+
+  const handleToggleGrid = useCallback(() => {
+    if (!scene) return
+    const newVisible = !scene.gridVisible
+    onUpdateScene(scene.id, {
+      gridVisible: newVisible,
+      gridSnap: newVisible,
+    })
+  }, [scene, onUpdateScene])
+
+  const handleToggleGridConfig = useCallback(() => {
+    setShowGridConfig((prev) => !prev)
+  }, [])
+
   return (
     <div
       className="bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
@@ -53,29 +74,46 @@ export function TacticalPanel({
       {/* Header bar */}
       <div className="border-b border-border-glass flex items-center justify-between px-4 py-2 shrink-0">
         <span className="text-text-primary text-sm font-medium">Tactical Map</span>
-        <button
-          onClick={onClose}
-          className="bg-transparent border-none cursor-pointer text-text-muted p-1 flex transition-colors duration-fast hover:text-text-primary"
-        >
-          <X size={18} strokeWidth={1.5} />
-        </button>
       </div>
 
-      {/* Panel body */}
-      <div style={{ flex: 1, overflow: 'hidden' }}>
-        <KonvaMap
-          scene={scene}
-          tokens={tokens}
-          getEntity={getEntity}
-          mySeatId={mySeatId}
-          role={role}
-          selectedTokenId={selectedTokenId}
-          onSelectToken={onSelectToken}
-          onUpdateToken={onUpdateToken}
-          onDeleteToken={onDeleteToken}
-          onAddToken={onAddToken}
-          onDropEntityOnMap={onDropEntityOnMap}
+      {/* Panel body: toolbar + map side by side */}
+      <div style={{ flex: 1, overflow: 'hidden', display: 'flex', position: 'relative' }}>
+        {/* Left toolbar */}
+        <TacticalToolbar
+          gridVisible={scene?.gridVisible ?? false}
+          gridSnap={scene?.gridSnap ?? false}
+          showGridConfig={showGridConfig}
+          onToggleGridConfig={handleToggleGridConfig}
+          onToggleGrid={handleToggleGrid}
+          onAdvanceInitiative={onAdvanceInitiative}
+          onClose={onClose}
         />
+
+        {/* Map area */}
+        <div style={{ flex: 1, overflow: 'hidden' }}>
+          <KonvaMap
+            scene={scene}
+            tokens={tokens}
+            getEntity={getEntity}
+            mySeatId={mySeatId}
+            role={role}
+            selectedTokenId={selectedTokenId}
+            onSelectToken={onSelectToken}
+            onUpdateToken={onUpdateToken}
+            onDeleteToken={onDeleteToken}
+            onAddToken={onAddToken}
+            onDropEntityOnMap={onDropEntityOnMap}
+          />
+        </div>
+
+        {/* Grid config pop-out */}
+        {showGridConfig && scene && (
+          <GridConfigPanel
+            scene={scene}
+            onUpdateScene={onUpdateScene}
+            onClose={() => setShowGridConfig(false)}
+          />
+        )}
       </div>
     </div>
   )

--- a/src/combat/TacticalToolbar.tsx
+++ b/src/combat/TacticalToolbar.tsx
@@ -1,0 +1,184 @@
+import {
+  MousePointer2,
+  Ruler,
+  Circle,
+  Grid3x3,
+  Settings,
+  ChevronRight,
+  X,
+} from 'lucide-react'
+import { useUiStore, type ActiveTool } from '../stores/uiStore'
+
+interface TacticalToolbarProps {
+  gridVisible: boolean
+  gridSnap: boolean
+  showGridConfig: boolean
+  onToggleGridConfig: () => void
+  onToggleGrid: () => void
+  onAdvanceInitiative: () => void
+  onClose: () => void
+}
+
+type RangeSubTool = 'range-circle' | 'range-cone' | 'range-rect'
+const RANGE_TOOLS: RangeSubTool[] = ['range-circle', 'range-cone', 'range-rect']
+
+function isRangeTool(tool: ActiveTool): tool is RangeSubTool {
+  return RANGE_TOOLS.includes(tool as RangeSubTool)
+}
+
+export function TacticalToolbar({
+  gridVisible,
+  showGridConfig,
+  onToggleGridConfig,
+  onToggleGrid,
+  onAdvanceInitiative,
+  onClose,
+}: TacticalToolbarProps) {
+  const activeTool = useUiStore((s) => s.activeTool)
+  const setActiveTool = useUiStore((s) => s.setActiveTool)
+
+  return (
+    <div
+      className="bg-glass backdrop-blur-[12px] border-r border-border-glass flex flex-col items-center py-2 gap-0.5 shrink-0"
+      style={{ width: 40 }}
+    >
+      {/* Tool group: Select / Measure / Range */}
+      <ToolButton
+        icon={<MousePointer2 size={18} strokeWidth={1.5} />}
+        active={activeTool === 'select'}
+        title="Select / Move"
+        onClick={() => setActiveTool('select')}
+      />
+      <ToolButton
+        icon={<Ruler size={18} strokeWidth={1.5} />}
+        active={activeTool === 'measure'}
+        title="Measure distance"
+        onClick={() => setActiveTool('measure')}
+      />
+      <RangeButton
+        activeTool={activeTool}
+        onSelect={setActiveTool}
+      />
+
+      {/* Divider */}
+      <div className="w-6 h-px bg-border-glass my-1" />
+
+      {/* Grid group */}
+      <ToolButton
+        icon={<Grid3x3 size={18} strokeWidth={1.5} />}
+        active={gridVisible}
+        title="Toggle grid"
+        onClick={onToggleGrid}
+      />
+      <ToolButton
+        icon={<Settings size={18} strokeWidth={1.5} />}
+        active={showGridConfig}
+        title="Grid settings"
+        onClick={onToggleGridConfig}
+      />
+
+      {/* Divider */}
+      <div className="w-6 h-px bg-border-glass my-1" />
+
+      {/* Action group */}
+      <ToolButton
+        icon={<ChevronRight size={18} strokeWidth={1.5} />}
+        active={false}
+        title="Next turn"
+        onClick={onAdvanceInitiative}
+      />
+      <ToolButton
+        icon={<X size={18} strokeWidth={1.5} />}
+        active={false}
+        title="Close map"
+        onClick={onClose}
+      />
+    </div>
+  )
+}
+
+// ── Tool Button ──
+
+function ToolButton({
+  icon,
+  active,
+  title,
+  onClick,
+}: {
+  icon: React.ReactNode
+  active: boolean
+  title: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`
+        w-8 h-8 flex items-center justify-center rounded cursor-pointer
+        border-none transition-colors duration-fast
+        ${active ? 'bg-accent text-deep' : 'bg-transparent text-text-muted hover:text-text-primary hover:bg-hover'}
+      `}
+    >
+      {icon}
+    </button>
+  )
+}
+
+// ── Range Button with sub-menu ──
+
+const RANGE_LABELS: Record<RangeSubTool, string> = {
+  'range-circle': 'Circle',
+  'range-cone': 'Cone',
+  'range-rect': 'Rectangle',
+}
+
+function RangeButton({
+  activeTool,
+  onSelect,
+}: {
+  activeTool: ActiveTool
+  onSelect: (tool: ActiveTool) => void
+}) {
+  const isActive = isRangeTool(activeTool)
+
+  return (
+    <div className="relative group">
+      <ToolButton
+        icon={<Circle size={18} strokeWidth={1.5} />}
+        active={isActive}
+        title="Range templates"
+        onClick={() => {
+          // Toggle: if already a range tool, cycle; otherwise default to circle
+          if (isActive) {
+            onSelect('select')
+          } else {
+            onSelect('range-circle')
+          }
+        }}
+      />
+      {/* Sub-menu on hover */}
+      <div
+        className="
+          absolute left-full top-0 ml-1 hidden group-hover:flex flex-col
+          bg-glass backdrop-blur-[12px] border border-border-glass rounded
+          py-1 z-10 min-w-[100px]
+        "
+      >
+        {RANGE_TOOLS.map((tool) => (
+          <button
+            key={tool}
+            onClick={() => onSelect(tool)}
+            className={`
+              px-3 py-1.5 text-xs text-left border-none cursor-pointer
+              transition-colors duration-fast
+              ${activeTool === tool ? 'bg-accent text-deep' : 'bg-transparent text-text-muted hover:text-text-primary hover:bg-hover'}
+            `}
+          >
+            {RANGE_LABELS[tool]}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/combat/tools/GridConfigPanel.tsx
+++ b/src/combat/tools/GridConfigPanel.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { Scene } from '../../stores/worldStore'
+
+interface GridConfigPanelProps {
+  scene: Scene
+  onUpdateScene: (sceneId: string, updates: Partial<Scene>) => void
+  onClose: () => void
+}
+
+export function GridConfigPanel({ scene, onUpdateScene, onClose }: GridConfigPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Local state synced from scene props
+  const [gridSize, setGridSize] = useState(scene.gridSize)
+  const [gridOffsetX, setGridOffsetX] = useState(scene.gridOffsetX)
+  const [gridOffsetY, setGridOffsetY] = useState(scene.gridOffsetY)
+  const [gridColor, setGridColor] = useState(scene.gridColor)
+
+  // Re-sync local state when scene changes externally
+  useEffect(() => {
+    setGridSize(scene.gridSize)
+    setGridOffsetX(scene.gridOffsetX)
+    setGridOffsetY(scene.gridOffsetY)
+    setGridColor(scene.gridColor)
+  }, [scene.gridSize, scene.gridOffsetX, scene.gridOffsetY, scene.gridColor])
+
+  // Click outside to close
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [onClose])
+
+  const commitChange = useCallback(
+    (updates: Partial<Scene>) => {
+      onUpdateScene(scene.id, updates)
+    },
+    [scene.id, onUpdateScene],
+  )
+
+  return (
+    <div
+      ref={panelRef}
+      className="bg-glass backdrop-blur-[12px] border border-border-glass rounded-lg shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
+      style={{
+        position: 'absolute',
+        left: 48,
+        top: 8,
+        width: 200,
+        zIndex: 20,
+        padding: '12px',
+      }}
+    >
+      <div className="text-text-primary text-xs font-medium mb-3">Grid Settings</div>
+
+      <FieldRow label="Cell Size">
+        <NumberInput
+          value={gridSize}
+          min={10}
+          max={500}
+          onChange={(v) => {
+            setGridSize(v)
+            commitChange({ gridSize: v })
+          }}
+        />
+      </FieldRow>
+
+      <FieldRow label="Offset X">
+        <NumberInput
+          value={gridOffsetX}
+          min={-500}
+          max={500}
+          onChange={(v) => {
+            setGridOffsetX(v)
+            commitChange({ gridOffsetX: v })
+          }}
+        />
+      </FieldRow>
+
+      <FieldRow label="Offset Y">
+        <NumberInput
+          value={gridOffsetY}
+          min={-500}
+          max={500}
+          onChange={(v) => {
+            setGridOffsetY(v)
+            commitChange({ gridOffsetY: v })
+          }}
+        />
+      </FieldRow>
+
+      <FieldRow label="Color">
+        <input
+          type="color"
+          value={gridColor}
+          onChange={(e) => {
+            setGridColor(e.target.value)
+            commitChange({ gridColor: e.target.value })
+          }}
+          className="w-8 h-6 p-0 border border-border-glass rounded cursor-pointer bg-transparent"
+        />
+      </FieldRow>
+    </div>
+  )
+}
+
+// ── Helpers ──
+
+function FieldRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between mb-2">
+      <span className="text-text-muted text-xs">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function NumberInput({
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  value: number
+  min: number
+  max: number
+  onChange: (v: number) => void
+}) {
+  return (
+    <input
+      type="number"
+      value={value}
+      min={min}
+      max={max}
+      onChange={(e) => {
+        const v = parseInt(e.target.value, 10)
+        if (!isNaN(v) && v >= min && v <= max) {
+          onChange(v)
+        }
+      }}
+      className="w-16 px-1.5 py-0.5 text-xs text-text-primary bg-deep border border-border-glass rounded text-right"
+    />
+  )
+}

--- a/src/combat/tools/MeasureTool.tsx
+++ b/src/combat/tools/MeasureTool.tsx
@@ -1,0 +1,220 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { Layer, Line, Rect, Text, Group } from 'react-konva'
+import type Konva from 'konva'
+import type { Scene } from '../../stores/worldStore'
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface Measurement {
+  start: Point
+  end: Point
+  distance: string
+}
+
+interface MeasureToolProps {
+  active: boolean
+  scene: Scene
+  stageRef: React.RefObject<Konva.Stage | null>
+}
+
+const MEASURE_COLOR = '#D4A055'
+const MEASURE_DASH = [8, 4]
+const LABEL_FONT_SIZE = 13
+const LABEL_PADDING = 4
+const LABEL_BG_COLOR = 'rgba(20, 15, 12, 0.88)'
+
+function calcDistance(start: Point, end: Point, scene: Scene): string {
+  const dx = end.x - start.x
+  const dy = end.y - start.y
+  const pixelDist = Math.sqrt(dx * dx + dy * dy)
+
+  if (scene.gridSnap && scene.gridSize > 0) {
+    const cells = Math.round(pixelDist / scene.gridSize)
+    return `${cells} cell${cells !== 1 ? 's' : ''}`
+  }
+  return `${Math.round(pixelDist)} px`
+}
+
+export function MeasureTool({ active, scene, stageRef }: MeasureToolProps) {
+  const [drawing, setDrawing] = useState<{ start: Point; end: Point } | null>(null)
+  const [persisted, setPersisted] = useState<Measurement[]>([])
+  const isDrawingRef = useRef(false)
+  const shiftRef = useRef(false)
+
+  // Track Shift key state
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') shiftRef.current = true
+      // Escape clears persisted measurements
+      if (e.key === 'Escape') {
+        setPersisted([])
+        setDrawing(null)
+        isDrawingRef.current = false
+      }
+    }
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') shiftRef.current = false
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+    }
+  }, [])
+
+  // Clear drawing state when tool is deactivated
+  useEffect(() => {
+    if (!active) {
+      setDrawing(null)
+      isDrawingRef.current = false
+    }
+  }, [active])
+
+  // Attach Stage mouse event handlers
+  useEffect(() => {
+    if (!active) return
+    const stage = stageRef.current
+    if (!stage) return
+
+    const getMapPos = (): Point | null => {
+      const pos = stage.getRelativePointerPosition()
+      if (!pos) return null
+      return { x: pos.x, y: pos.y }
+    }
+
+    const handleMouseDown = (e: Konva.KonvaEventObject<MouseEvent>) => {
+      // Right click cancels
+      if (e.evt.button === 2) {
+        setDrawing(null)
+        isDrawingRef.current = false
+        return
+      }
+      if (e.evt.button !== 0) return
+
+      const pos = getMapPos()
+      if (!pos) return
+
+      isDrawingRef.current = true
+      setDrawing({ start: pos, end: pos })
+    }
+
+    const handleMouseMove = () => {
+      if (!isDrawingRef.current) return
+      const pos = getMapPos()
+      if (!pos) return
+
+      setDrawing((prev) => prev ? { ...prev, end: pos } : null)
+    }
+
+    const handleMouseUp = (e: Konva.KonvaEventObject<MouseEvent>) => {
+      if (!isDrawingRef.current) return
+      if (e.evt.button !== 0) return
+      isDrawingRef.current = false
+
+      setDrawing((prev) => {
+        if (!prev) return null
+        if (shiftRef.current) {
+          // Persist the measurement
+          const distance = calcDistance(prev.start, prev.end, scene)
+          setPersisted((arr) => [...arr, { start: prev.start, end: prev.end, distance }])
+        }
+        return null
+      })
+    }
+
+    stage.on('mousedown.measure', handleMouseDown)
+    stage.on('mousemove.measure', handleMouseMove)
+    stage.on('mouseup.measure', handleMouseUp)
+
+    return () => {
+      stage.off('mousedown.measure')
+      stage.off('mousemove.measure')
+      stage.off('mouseup.measure')
+    }
+  }, [active, scene, stageRef])
+
+  // Nothing to render if tool is inactive and no persisted measurements
+  if (!active && persisted.length === 0) return null
+
+  const currentDistance = drawing ? calcDistance(drawing.start, drawing.end, scene) : ''
+
+  return (
+    <Layer listening={false}>
+      {/* Persisted measurements */}
+      {persisted.map((m, i) => (
+        <MeasurementLine key={i} start={m.start} end={m.end} distance={m.distance} />
+      ))}
+
+      {/* Active drawing */}
+      {drawing && (
+        <MeasurementLine start={drawing.start} end={drawing.end} distance={currentDistance} />
+      )}
+    </Layer>
+  )
+}
+
+// ── Measurement Line + Label ──
+
+function MeasurementLine({
+  start,
+  end,
+  distance,
+}: {
+  start: Point
+  end: Point
+  distance: string
+}) {
+  const midX = (start.x + end.x) / 2
+  const midY = (start.y + end.y) / 2
+
+  // Estimate text width for background rect
+  const textWidth = distance.length * (LABEL_FONT_SIZE * 0.6) + LABEL_PADDING * 2
+  const textHeight = LABEL_FONT_SIZE + LABEL_PADDING * 2
+
+  return (
+    <>
+      <Line
+        points={[start.x, start.y, end.x, end.y]}
+        stroke={MEASURE_COLOR}
+        strokeWidth={2}
+        dash={MEASURE_DASH}
+      />
+      {/* Small circle at start */}
+      <Line
+        points={[start.x - 3, start.y, start.x + 3, start.y]}
+        stroke={MEASURE_COLOR}
+        strokeWidth={2}
+      />
+      {/* Small circle at end */}
+      <Line
+        points={[end.x - 3, end.y, end.x + 3, end.y]}
+        stroke={MEASURE_COLOR}
+        strokeWidth={2}
+      />
+      {/* Label background */}
+      <Group x={midX - textWidth / 2} y={midY - textHeight / 2}>
+        <Rect
+          width={textWidth}
+          height={textHeight}
+          fill={LABEL_BG_COLOR}
+          cornerRadius={3}
+        />
+        <Text
+          text={distance}
+          fontSize={LABEL_FONT_SIZE}
+          fill={MEASURE_COLOR}
+          width={textWidth}
+          height={textHeight}
+          align="center"
+          verticalAlign="middle"
+          fontFamily="sans-serif"
+        />
+      </Group>
+    </>
+  )
+}

--- a/src/combat/tools/RangeTemplate.tsx
+++ b/src/combat/tools/RangeTemplate.tsx
@@ -1,0 +1,310 @@
+import { useState, useEffect, useRef } from 'react'
+import { Layer, Circle, Wedge, Rect, Line, Text, Group, Rect as BgRect } from 'react-konva'
+import type Konva from 'konva'
+import type { Scene } from '../../stores/worldStore'
+import type { ActiveTool } from '../../stores/uiStore'
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface RangeShape {
+  mode: 'circle' | 'cone' | 'rect'
+  origin: Point
+  end: Point
+  label: string
+}
+
+interface RangeTemplateProps {
+  activeTool: ActiveTool
+  scene: Scene
+  stageRef: React.RefObject<Konva.Stage | null>
+}
+
+const RANGE_FILL = 'rgba(212, 160, 85, 0.15)'
+const RANGE_STROKE = '#D4A055'
+const RANGE_DASH = [6, 3]
+const CONE_ANGLE = 90
+const LABEL_FONT_SIZE = 12
+const LABEL_PADDING = 3
+const LABEL_BG_COLOR = 'rgba(20, 15, 12, 0.88)'
+
+function getRangeMode(tool: ActiveTool): 'circle' | 'cone' | 'rect' | null {
+  if (tool === 'range-circle') return 'circle'
+  if (tool === 'range-cone') return 'cone'
+  if (tool === 'range-rect') return 'rect'
+  return null
+}
+
+function calcLabel(mode: string, origin: Point, end: Point, scene: Scene): string {
+  const dx = end.x - origin.x
+  const dy = end.y - origin.y
+  const pixelDist = Math.sqrt(dx * dx + dy * dy)
+
+  const inCells = scene.gridSnap && scene.gridSize > 0
+
+  if (mode === 'circle') {
+    const radius = inCells ? Math.round(pixelDist / scene.gridSize) : Math.round(pixelDist)
+    const unit = inCells ? 'cell' : 'px'
+    return `r=${radius} ${unit}${radius !== 1 && inCells ? 's' : ''}`
+  }
+  if (mode === 'cone') {
+    const length = inCells ? Math.round(pixelDist / scene.gridSize) : Math.round(pixelDist)
+    const unit = inCells ? 'cell' : 'px'
+    return `${length} ${unit}${length !== 1 && inCells ? 's' : ''}`
+  }
+  if (mode === 'rect') {
+    const w = Math.abs(dx)
+    const h = Math.abs(dy)
+    if (inCells) {
+      const cw = Math.round(w / scene.gridSize)
+      const ch = Math.round(h / scene.gridSize)
+      return `${cw}x${ch} cells`
+    }
+    return `${Math.round(w)}x${Math.round(h)} px`
+  }
+  return ''
+}
+
+export function RangeTemplate({ activeTool, scene, stageRef }: RangeTemplateProps) {
+  const mode = getRangeMode(activeTool)
+  const [drawing, setDrawing] = useState<{ origin: Point; end: Point } | null>(null)
+  const [persisted, setPersisted] = useState<RangeShape[]>([])
+  const isDrawingRef = useRef(false)
+  const shiftRef = useRef(false)
+
+  // Track Shift key state
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') shiftRef.current = true
+      if (e.key === 'Escape') {
+        setPersisted([])
+        setDrawing(null)
+        isDrawingRef.current = false
+      }
+    }
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') shiftRef.current = false
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+    }
+  }, [])
+
+  // Clear drawing when tool mode changes
+  useEffect(() => {
+    setDrawing(null)
+    isDrawingRef.current = false
+  }, [activeTool])
+
+  // Attach Stage mouse event handlers
+  useEffect(() => {
+    if (!mode) return
+    const stage = stageRef.current
+    if (!stage) return
+
+    const getMapPos = (): Point | null => {
+      const pos = stage.getRelativePointerPosition()
+      if (!pos) return null
+      return { x: pos.x, y: pos.y }
+    }
+
+    const handleMouseDown = (e: Konva.KonvaEventObject<MouseEvent>) => {
+      if (e.evt.button === 2) {
+        setDrawing(null)
+        isDrawingRef.current = false
+        return
+      }
+      if (e.evt.button !== 0) return
+
+      const pos = getMapPos()
+      if (!pos) return
+
+      isDrawingRef.current = true
+      setDrawing({ origin: pos, end: pos })
+    }
+
+    const handleMouseMove = () => {
+      if (!isDrawingRef.current) return
+      const pos = getMapPos()
+      if (!pos) return
+
+      setDrawing((prev) => prev ? { ...prev, end: pos } : null)
+    }
+
+    const handleMouseUp = (e: Konva.KonvaEventObject<MouseEvent>) => {
+      if (!isDrawingRef.current) return
+      if (e.evt.button !== 0) return
+      isDrawingRef.current = false
+
+      setDrawing((prev) => {
+        if (!prev || !mode) return null
+        if (shiftRef.current) {
+          const label = calcLabel(mode, prev.origin, prev.end, scene)
+          setPersisted((arr) => [...arr, { mode, origin: prev.origin, end: prev.end, label }])
+        }
+        return null
+      })
+    }
+
+    stage.on('mousedown.range', handleMouseDown)
+    stage.on('mousemove.range', handleMouseMove)
+    stage.on('mouseup.range', handleMouseUp)
+
+    return () => {
+      stage.off('mousedown.range')
+      stage.off('mousemove.range')
+      stage.off('mouseup.range')
+    }
+  }, [mode, scene, stageRef])
+
+  // Nothing to render if no active range tool and no persisted shapes
+  if (!mode && persisted.length === 0) return null
+
+  return (
+    <Layer listening={false}>
+      {/* Persisted range shapes */}
+      {persisted.map((shape, i) => (
+        <RangeShapeRenderer key={i} shape={shape} />
+      ))}
+
+      {/* Active drawing */}
+      {drawing && mode && (
+        <RangeShapeRenderer
+          shape={{
+            mode,
+            origin: drawing.origin,
+            end: drawing.end,
+            label: calcLabel(mode, drawing.origin, drawing.end, scene),
+          }}
+        />
+      )}
+    </Layer>
+  )
+}
+
+// ── Shape Renderer ──
+
+function RangeShapeRenderer({ shape }: { shape: RangeShape }) {
+  const { mode, origin, end, label } = shape
+
+  if (mode === 'circle') {
+    const dx = end.x - origin.x
+    const dy = end.y - origin.y
+    const radius = Math.sqrt(dx * dx + dy * dy)
+
+    return (
+      <>
+        <Circle
+          x={origin.x}
+          y={origin.y}
+          radius={radius}
+          fill={RANGE_FILL}
+          stroke={RANGE_STROKE}
+          strokeWidth={1.5}
+          dash={RANGE_DASH}
+        />
+        {/* Radius line */}
+        <Line
+          points={[origin.x, origin.y, end.x, end.y]}
+          stroke={RANGE_STROKE}
+          strokeWidth={1}
+          dash={RANGE_DASH}
+          opacity={0.6}
+        />
+        <ShapeLabel x={end.x} y={end.y - 20} text={label} />
+      </>
+    )
+  }
+
+  if (mode === 'cone') {
+    const dx = end.x - origin.x
+    const dy = end.y - origin.y
+    const radius = Math.sqrt(dx * dx + dy * dy)
+    // Konva Wedge rotation: 0 = right, goes clockwise. atan2 gives angle from positive X axis.
+    const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI
+
+    return (
+      <>
+        <Wedge
+          x={origin.x}
+          y={origin.y}
+          radius={radius}
+          angle={CONE_ANGLE}
+          rotation={angleDeg - CONE_ANGLE / 2}
+          fill={RANGE_FILL}
+          stroke={RANGE_STROKE}
+          strokeWidth={1.5}
+          dash={RANGE_DASH}
+        />
+        {/* Direction line */}
+        <Line
+          points={[origin.x, origin.y, end.x, end.y]}
+          stroke={RANGE_STROKE}
+          strokeWidth={1}
+          dash={RANGE_DASH}
+          opacity={0.6}
+        />
+        <ShapeLabel x={end.x} y={end.y - 20} text={label} />
+      </>
+    )
+  }
+
+  if (mode === 'rect') {
+    const x = Math.min(origin.x, end.x)
+    const y = Math.min(origin.y, end.y)
+    const w = Math.abs(end.x - origin.x)
+    const h = Math.abs(end.y - origin.y)
+
+    return (
+      <>
+        <Rect
+          x={x}
+          y={y}
+          width={w}
+          height={h}
+          fill={RANGE_FILL}
+          stroke={RANGE_STROKE}
+          strokeWidth={1.5}
+          dash={RANGE_DASH}
+        />
+        <ShapeLabel x={x + w / 2} y={y - 20} text={label} />
+      </>
+    )
+  }
+
+  return null
+}
+
+// ── Shape Label ──
+
+function ShapeLabel({ x, y, text }: { x: number; y: number; text: string }) {
+  const textWidth = text.length * (LABEL_FONT_SIZE * 0.6) + LABEL_PADDING * 2
+  const textHeight = LABEL_FONT_SIZE + LABEL_PADDING * 2
+
+  return (
+    <Group x={x - textWidth / 2} y={y - textHeight / 2}>
+      <BgRect
+        width={textWidth}
+        height={textHeight}
+        fill={LABEL_BG_COLOR}
+        cornerRadius={3}
+      />
+      <Text
+        text={text}
+        fontSize={LABEL_FONT_SIZE}
+        fill={RANGE_STROKE}
+        width={textWidth}
+        height={textHeight}
+        align="center"
+        verticalAlign="middle"
+        fontFamily="sans-serif"
+      />
+    </Group>
+  )
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -9,16 +9,20 @@ interface ContextMenuState {
   y: number
 }
 
+export type ActiveTool = 'select' | 'measure' | 'range-circle' | 'range-cone' | 'range-rect'
+
 interface UiState {
   inspectedCharacterId: string | null
   selectedTokenId: string | null
   bgContextMenu: ContextMenuState | null
   editingHandout: HandoutAsset | null
+  activeTool: ActiveTool
 
   setInspectedCharacterId: (id: string | null) => void
   setSelectedTokenId: (id: string | null) => void
   setBgContextMenu: (menu: ContextMenuState | null) => void
   setEditingHandout: (asset: HandoutAsset | null) => void
+  setActiveTool: (tool: ActiveTool) => void
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -26,9 +30,11 @@ export const useUiStore = create<UiState>((set) => ({
   selectedTokenId: null,
   bgContextMenu: null,
   editingHandout: null,
+  activeTool: 'select',
 
   setInspectedCharacterId: (id) => set({ inspectedCharacterId: id }),
   setSelectedTokenId: (id) => set({ selectedTokenId: id }),
   setBgContextMenu: (menu) => set({ bgContextMenu: menu }),
   setEditingHandout: (asset) => set({ editingHandout: asset }),
+  setActiveTool: (tool) => set({ activeTool: tool }),
 }))


### PR DESCRIPTION
## Summary
- **TacticalToolbar**: Vertical tool strip on map panel left edge with mutually exclusive tool modes (select, measure, range-circle/cone/rect), grid toggle/config, initiative advance, and close buttons
- **MeasureTool**: Distance measurement line drawn by dragging on canvas — shows dashed amber line with distance label (cells or pixels). Shift+drag persists measurements, Escape clears
- **RangeTemplate**: Three area-of-effect shapes (circle, cone 90°, rectangle) with semi-transparent fill + dashed border + size labels. Same Shift-persist behavior
- **GridConfigPanel**: Pop-out panel for live grid settings editing (cell size, offset X/Y, color picker)
- Stage `draggable` disabled when non-select tool is active; wheel zoom always works

## Files
- **New**: `TacticalToolbar.tsx`, `tools/MeasureTool.tsx`, `tools/RangeTemplate.tsx`, `tools/GridConfigPanel.tsx`
- **Modified**: `KonvaMap.tsx`, `TacticalPanel.tsx`, `App.tsx`, `uiStore.ts`

## Test Plan
- [ ] Open tactical map, verify toolbar appears on left edge
- [ ] Select tool (default): tokens draggable, stage pannable
- [ ] Measure tool: drag to draw line with distance label, right-click cancels, Shift+drag persists
- [ ] Range circle: drag from center to set radius
- [ ] Range cone: drag from origin to set direction, 90° wedge displayed
- [ ] Range rectangle: drag corner to corner
- [ ] Grid toggle: hides/shows grid + snap
- [ ] Grid config: opens panel with live preview for cell size, offsets, color
- [ ] Next Turn button advances initiative
- [ ] Close button exits combat mode
- [ ] All 213 tests pass, 0 TypeScript errors