### PR TITLE
feat: migrate entity text fields to Y.Text CRDT

### DIFF
--- a/src/entities/__tests__/entityLifecycle.sync.test.ts
+++ b/src/entities/__tests__/entityLifecycle.sync.test.ts
@@ -28,7 +28,7 @@ function flushInAct(
 // ── Entity field concurrent updates ──────────────────────────
 
 describe('entity concurrent field updates', () => {
-  it('same field concurrent update — both clients converge', () => {
+  it('same field concurrent update — both clients converge (Y.Text merge)', () => {
     const { doc1, doc2, world1, world2 } = createDeferredPair()
     const hook1 = renderHook(() => useEntities(world1, doc1))
     const hook2 = renderHook(() => useEntities(world2, doc2))
@@ -41,14 +41,18 @@ describe('entity concurrent field updates', () => {
     act(() => hook1.result.current.updateEntity('e1', { name: 'Name-A' }))
     act(() => hook2.result.current.updateEntity('e1', { name: 'Name-B' }))
 
-    // Flush sync — Yjs resolves conflict deterministically
+    // Flush sync — Y.Text merges concurrent inserts (character-level CRDT)
     flushInAct(doc1, doc2)
 
-    // Both clients should agree on the same name (one wins)
+    // Both clients should converge to the same merged value.
+    // With Y.Text, concurrent delete-all + insert produces a merge of both
+    // texts (not last-write-wins). The merged result contains both strings.
     const e1 = hook1.result.current.entities.find((e) => e.id === 'e1')
     const e2 = hook2.result.current.entities.find((e) => e.id === 'e1')
     expect(e1?.name).toBe(e2?.name)
-    expect(['Name-A', 'Name-B']).toContain(e1?.name)
+    // Y.Text merge: both inserts survive, so the result contains both substrings
+    expect(e1?.name).toContain('Name-A')
+    expect(e1?.name).toContain('Name-B')
   })
 
   it('different fields concurrent update — both merge', () => {

--- a/src/entities/useEntities.ts
+++ b/src/entities/useEntities.ts
@@ -2,6 +2,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import * as Y from 'yjs'
 import type { Entity, EntityPermissions, PermissionLevel } from '../shared/entityTypes'
+import { readTextField, writeTextField, updateTextField } from '../shared/yTextHelper'
 import type { WorldMaps } from '../yjs/useWorld'
 
 /** Read permissions from a nested Y.Map back to a plain EntityPermissions object */
@@ -40,12 +41,12 @@ function readRuleData(yMap: Y.Map<unknown>): unknown {
 function readYMapEntity(yMap: Y.Map<unknown>): Entity {
   return {
     id: yMap.get('id') as string,
-    name: (yMap.get('name') as string) ?? '',
+    name: readTextField(yMap, 'name'),
     imageUrl: (yMap.get('imageUrl') as string) ?? '',
     color: (yMap.get('color') as string) ?? '',
     size: (yMap.get('size') as number) ?? 1,
     blueprintId: yMap.get('blueprintId') as string | undefined,
-    notes: (yMap.get('notes') as string) ?? '',
+    notes: readTextField(yMap, 'notes'),
     ruleData: readRuleData(yMap),
     permissions: readPermissions(yMap),
     persistent: (yMap.get('persistent') as boolean) ?? false,
@@ -77,12 +78,12 @@ function writeRuleData(entityYMap: Y.Map<unknown>, ruleData: unknown) {
 
 function setYMapFields(yMap: Y.Map<unknown>, entity: Entity) {
   yMap.set('id', entity.id)
-  yMap.set('name', entity.name)
+  writeTextField(yMap, 'name', entity.name)
   yMap.set('imageUrl', entity.imageUrl)
   yMap.set('color', entity.color)
   yMap.set('size', entity.size)
   if (entity.blueprintId) yMap.set('blueprintId', entity.blueprintId)
-  yMap.set('notes', entity.notes)
+  writeTextField(yMap, 'notes', entity.notes)
   yMap.set('persistent', entity.persistent)
   writeRuleData(yMap, entity.ruleData)
   writePermissions(yMap, entity.permissions)
@@ -171,6 +172,8 @@ export function useEntities(world: WorldMaps, yDoc: Y.Doc) {
             updatePermissions(entityYMap, value as EntityPermissions)
           } else if (key === 'ruleData') {
             updateRuleData(entityYMap, value)
+          } else if (key === 'name' || key === 'notes') {
+            updateTextField(entityYMap, key, value as string)
           } else {
             entityYMap.set(key, value)
           }

--- a/src/shared/yTextHelper.ts
+++ b/src/shared/yTextHelper.ts
@@ -1,0 +1,31 @@
+// src/shared/yTextHelper.ts
+// Helpers for reading/writing Y.Text fields with backward compat for plain strings.
+
+import * as Y from 'yjs'
+
+/** Read a field that might be Y.Text or plain string (backward compat) */
+export function readTextField(yMap: Y.Map<unknown>, key: string): string {
+  const val = yMap.get(key)
+  if (val instanceof Y.Text) return val.toString()
+  if (typeof val === 'string') return val
+  return ''
+}
+
+/** Write a text field as Y.Text, creating a new Y.Text instance */
+export function writeTextField(yMap: Y.Map<unknown>, key: string, text: string): void {
+  const yText = new Y.Text()
+  yText.insert(0, text)
+  yMap.set(key, yText)
+}
+
+/** Update an existing Y.Text field in-place (replace all content) */
+export function updateTextField(yMap: Y.Map<unknown>, key: string, text: string): void {
+  const existing = yMap.get(key)
+  if (existing instanceof Y.Text) {
+    existing.delete(0, existing.length)
+    if (text.length > 0) existing.insert(0, text)
+  } else {
+    // First time or migration from plain string: create Y.Text
+    writeTextField(yMap, key, text)
+  }
+}

--- a/src/stores/worldStore.ts
+++ b/src/stores/worldStore.ts
@@ -6,6 +6,7 @@
 import { create } from 'zustand'
 import * as Y from 'yjs'
 import type { Entity, EntityPermissions, MapToken, Blueprint } from '../shared/entityTypes'
+import { readTextField, writeTextField, updateTextField } from '../shared/yTextHelper'
 import type { ShowcaseItem } from '../showcase/showcaseTypes'
 
 // ── Types ──
@@ -88,12 +89,12 @@ function readRuleData(yMap: Y.Map<unknown>): unknown {
 function readYMapEntity(yMap: Y.Map<unknown>): Entity {
   return {
     id: yMap.get('id') as string,
-    name: (yMap.get('name') as string) ?? '',
+    name: readTextField(yMap, 'name'),
     imageUrl: (yMap.get('imageUrl') as string) ?? '',
     color: (yMap.get('color') as string) ?? '',
     size: (yMap.get('size') as number) ?? 1,
     blueprintId: yMap.get('blueprintId') as string | undefined,
-    notes: (yMap.get('notes') as string) ?? '',
+    notes: readTextField(yMap, 'notes'),
     ruleData: readRuleData(yMap),
     permissions: readPermissions(yMap),
     persistent: (yMap.get('persistent') as boolean) ?? false,
@@ -209,12 +210,12 @@ function writeRuleData(entityYMap: Y.Map<unknown>, ruleData: unknown) {
 
 function setYMapFields(yMap: Y.Map<unknown>, entity: Entity) {
   yMap.set('id', entity.id)
-  yMap.set('name', entity.name)
+  writeTextField(yMap, 'name', entity.name)
   yMap.set('imageUrl', entity.imageUrl)
   yMap.set('color', entity.color)
   yMap.set('size', entity.size)
   if (entity.blueprintId) yMap.set('blueprintId', entity.blueprintId)
-  yMap.set('notes', entity.notes)
+  writeTextField(yMap, 'notes', entity.notes)
   yMap.set('persistent', entity.persistent)
   writeRuleData(yMap, entity.ruleData)
   writePermissions(yMap, entity.permissions)
@@ -606,6 +607,8 @@ export const useWorldStore = create<WorldState>((set, get) => ({
           updatePermissionsInPlace(entityYMap, value as EntityPermissions)
         } else if (key === 'ruleData') {
           updateRuleDataInPlace(entityYMap, value)
+        } else if (key === 'name' || key === 'notes') {
+          updateTextField(entityYMap, key, value as string)
         } else {
           entityYMap.set(key, value)
         }


### PR DESCRIPTION
## Summary
- Entity `name` and `notes` fields now stored as Y.Text for character-level conflict resolution
- Added `yTextHelper.ts` with backward-compatible read/write/update utilities
- Updated `useEntities.ts` and `worldStore.ts` to use Y.Text helpers
- Fixed concurrent update test to expect Y.Text merge behavior

## Test plan
- [x] 0 TypeScript errors
- [x] 213 tests pass (including updated concurrent update test)
- [ ] Verify name/notes editing works with existing string data (backward compat)
- [ ] Verify concurrent edits merge at character level