### PR TITLE
feat: add awareness resource drag and soft lock indicators

### DIFF
--- a/src/layout/CharacterEditPanel.tsx
+++ b/src/layout/CharacterEditPanel.tsx
@@ -12,6 +12,8 @@ import {
 import { barColorForKey, statusColor } from '../shared/tokenUtils'
 import { ResourceBar } from '../shared/ui/ResourceBar'
 import { MiniHoldButton } from '../shared/ui/MiniHoldButton'
+import { useIdentityStore } from '../stores/identityStore'
+import { useAwarenessResource, getRemoteEdit } from '../shared/hooks/useAwarenessResource'
 
 interface CharacterEditPanelProps {
   character: Entity
@@ -76,6 +78,16 @@ export function CharacterEditPanel({
   const [colorPickerOpen, setColorPickerOpen] = useState<'character' | number | null>(null)
   const colorPickerRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Awareness for resource drag broadcasting
+  const awareness = useIdentityStore((s) => s.getAwareness())
+  const mySeatId = useIdentityStore((s) => s.mySeatId)
+  const mySeat = useIdentityStore((s) => s.getMySeat())
+  const { broadcastEditing, clearEditing, remoteEdits } = useAwarenessResource(
+    awareness,
+    mySeatId,
+    mySeat?.color ?? null,
+  )
 
   // Close color picker on click outside
   useEffect(() => {
@@ -282,6 +294,7 @@ export function CharacterEditPanel({
   const renderResources = () => (
     <div>
       {resources.map((res, i) => {
+        const remoteEdit = getRemoteEdit(remoteEdits, character.id, String(i))
         return (
           <div key={i} style={{ marginBottom: 10 }}>
             {/* Header: name + current/max inputs + remove */}
@@ -372,6 +385,14 @@ export function CharacterEditPanel({
               draggable
               showButtons
               onChange={(val: number) => updateResource(i, { current: val })}
+              onDragStart={() => broadcastEditing(character.id, String(i), res.current)}
+              onDragMove={(val: number) => broadcastEditing(character.id, String(i), val)}
+              onDragEnd={(val: number) => {
+                updateResource(i, { current: val })
+                clearEditing()
+              }}
+              remoteDragValue={remoteEdit?.value ?? null}
+              softLockColor={remoteEdit?.color ?? null}
             />
             {/* Color picker -- collapsed by default */}
             {colorPickerOpen === i && (

--- a/src/layout/CharacterHoverPreview.tsx
+++ b/src/layout/CharacterHoverPreview.tsx
@@ -8,6 +8,8 @@ import {
 } from '../shared/entityAdapters'
 import { statusColor } from '../shared/tokenUtils'
 import { ResourceBar } from '../shared/ui/ResourceBar'
+import { useIdentityStore } from '../stores/identityStore'
+import { useAwarenessResource, getRemoteEdit } from '../shared/hooks/useAwarenessResource'
 
 interface CharacterHoverPreviewProps {
   character: Entity
@@ -24,6 +26,16 @@ export function CharacterHoverPreview({
   editable,
   onUpdateCharacter,
 }: CharacterHoverPreviewProps) {
+  // Awareness for resource drag broadcasting
+  const awareness = useIdentityStore((s) => s.getAwareness())
+  const mySeatId = useIdentityStore((s) => s.mySeatId)
+  const mySeat = useIdentityStore((s) => s.getMySeat())
+  const { broadcastEditing, clearEditing, remoteEdits } = useAwarenessResource(
+    awareness,
+    mySeatId,
+    mySeat?.color ?? null,
+  )
+
   const allResources = getEntityResources(character)
   const resources = allResources.filter((r) => r.max > 0)
   const attributes = getEntityAttributes(character)
@@ -186,21 +198,33 @@ export function CharacterHoverPreview({
       {/* Stats tab: Resources + Statuses */}
       {showStats && (
         <>
-          {resources.map((res, i) => (
-            <ResourceBar
-              key={i}
-              label={res.key || 'Unnamed'}
-              current={res.current}
-              max={res.max}
-              color={res.color}
-              height={canEdit ? 10 : 6}
-              valueDisplay={canEdit ? 'inline' : 'outside'}
-              draggable={canEdit}
-              showButtons={canEdit}
-              onChange={(val: number) => updateResource(i, { current: val })}
-              style={{ marginBottom: i < resources.length - 1 ? 5 : 0 }}
-            />
-          ))}
+          {resources.map((res, i) => {
+            const allIdx = allResources.indexOf(res)
+            const remoteEdit = getRemoteEdit(remoteEdits, character.id, String(allIdx))
+            return (
+              <ResourceBar
+                key={i}
+                label={res.key || 'Unnamed'}
+                current={res.current}
+                max={res.max}
+                color={res.color}
+                height={canEdit ? 10 : 6}
+                valueDisplay={canEdit ? 'inline' : 'outside'}
+                draggable={canEdit}
+                showButtons={canEdit}
+                onChange={(val: number) => updateResource(i, { current: val })}
+                onDragStart={canEdit ? () => broadcastEditing(character.id, String(allIdx), res.current) : undefined}
+                onDragMove={canEdit ? (val: number) => broadcastEditing(character.id, String(allIdx), val) : undefined}
+                onDragEnd={canEdit ? (val: number) => {
+                  updateResource(i, { current: val })
+                  clearEditing()
+                } : undefined}
+                remoteDragValue={remoteEdit?.value ?? null}
+                softLockColor={remoteEdit?.color ?? null}
+                style={{ marginBottom: i < resources.length - 1 ? 5 : 0 }}
+              />
+            )
+          })}
 
           {/* Statuses */}
           {(statuses.length > 0 || canEdit) && (

--- a/src/layout/MyCharacterCard.tsx
+++ b/src/layout/MyCharacterCard.tsx
@@ -12,6 +12,8 @@ import { barColorForKey, statusColor } from '../shared/tokenUtils'
 import { uploadAsset } from '../shared/assetUpload'
 import { ResourceBar } from '../shared/ui/ResourceBar'
 import { MiniHoldButton } from '../shared/ui/MiniHoldButton'
+import { useIdentityStore } from '../stores/identityStore'
+import { useAwarenessResource, getRemoteEdit } from '../shared/hooks/useAwarenessResource'
 
 interface MyCharacterCardProps {
   entity: Entity
@@ -79,6 +81,16 @@ export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps
   const [editName, setEditName] = useState(entity.name)
   const [colorPickerOpen, setColorPickerOpen] = useState<number | null>(null)
   const colorPickerRef = useRef<HTMLDivElement>(null)
+
+  // Awareness for resource drag broadcasting
+  const awareness = useIdentityStore((s) => s.getAwareness())
+  const mySeatId = useIdentityStore((s) => s.mySeatId)
+  const mySeat = useIdentityStore((s) => s.getMySeat())
+  const { broadcastEditing, clearEditing, remoteEdits } = useAwarenessResource(
+    awareness,
+    mySeatId,
+    mySeat?.color ?? null,
+  )
 
   // Sync editName when entity name changes externally
   useEffect(() => {
@@ -194,7 +206,9 @@ export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps
   /* -- Tab content renderers -- */
   const renderResources = () => (
     <div>
-      {resources.map((res, i) => (
+      {resources.map((res, i) => {
+        const remoteEdit = getRemoteEdit(remoteEdits, entity.id, String(i))
+        return (
         <div key={i} style={{ marginBottom: 10 }}>
           {/* Header: name + current/max inputs + remove */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
@@ -277,6 +291,14 @@ export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps
             draggable
             showButtons
             onChange={(val: number) => updateResource(i, { current: val })}
+            onDragStart={() => broadcastEditing(entity.id, String(i), res.current)}
+            onDragMove={(val: number) => broadcastEditing(entity.id, String(i), val)}
+            onDragEnd={(val: number) => {
+              updateResource(i, { current: val })
+              clearEditing()
+            }}
+            remoteDragValue={remoteEdit?.value ?? null}
+            softLockColor={remoteEdit?.color ?? null}
           />
           {/* Color picker -- collapsed by default */}
           {colorPickerOpen === i && (
@@ -307,7 +329,8 @@ export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps
             </div>
           )}
         </div>
-      ))}
+        )
+      })}
       <button
         onClick={addResource}
         style={addBtnStyle}

--- a/src/shared/hooks/useAwarenessResource.ts
+++ b/src/shared/hooks/useAwarenessResource.ts
@@ -1,0 +1,107 @@
+// src/shared/hooks/useAwarenessResource.ts
+// Broadcasts resource-drag awareness state and listens for remote drags.
+// During drag: broadcasts { entityId, field, value, seatId, color } at ~20fps.
+// On pointerUp: clears awareness state.
+// Consumers read `remoteEdits` to show live drag values and soft-lock indicators.
+
+import { useEffect, useState, useCallback, useRef } from 'react'
+import type { Awareness } from 'y-protocols/awareness'
+
+export interface AwarenessResourceState {
+  entityId: string
+  /** resource index as string, e.g. "0", "1" */
+  field: string
+  value: number
+  seatId: string
+  color: string
+}
+
+/** Keyed by `${entityId}:${field}` */
+export type RemoteEditMap = Map<string, AwarenessResourceState>
+
+const AWARENESS_FIELD = 'resourceDrag'
+const THROTTLE_MS = 50 // ~20fps
+
+function remoteEditKey(entityId: string, field: string): string {
+  return `${entityId}:${field}`
+}
+
+/**
+ * Hook that manages awareness-based resource drag broadcasting and listening.
+ *
+ * - `broadcastEditing(entityId, field, value)`: call on every drag move (throttled internally)
+ * - `clearEditing()`: call on pointerUp
+ * - `remoteEdits`: Map of currently active remote resource drags
+ */
+export function useAwarenessResource(
+  awareness: Awareness | null,
+  mySeatId: string | null,
+  mySeatColor: string | null,
+) {
+  const [remoteEdits, setRemoteEdits] = useState<RemoteEditMap>(() => new Map())
+  const lastBroadcastRef = useRef(0)
+
+  // Broadcast that the local user is dragging a resource
+  const broadcastEditing = useCallback(
+    (entityId: string, field: string, value: number) => {
+      if (!awareness || !mySeatId) return
+
+      const now = Date.now()
+      if (now - lastBroadcastRef.current < THROTTLE_MS) return
+      lastBroadcastRef.current = now
+
+      awareness.setLocalStateField(AWARENESS_FIELD, {
+        entityId,
+        field,
+        value,
+        seatId: mySeatId,
+        color: mySeatColor ?? '#3b82f6',
+      } satisfies AwarenessResourceState)
+    },
+    [awareness, mySeatId, mySeatColor],
+  )
+
+  // Clear the local editing state (call on pointerUp)
+  const clearEditing = useCallback(() => {
+    if (!awareness) return
+    awareness.setLocalStateField(AWARENESS_FIELD, null)
+  }, [awareness])
+
+  // Listen for remote clients' editing states
+  useEffect(() => {
+    if (!awareness) return
+
+    const update = () => {
+      const next: RemoteEditMap = new Map()
+      awareness.getStates().forEach((state, clientId) => {
+        if (clientId === awareness.clientID) return
+        const drag = state[AWARENESS_FIELD] as AwarenessResourceState | null | undefined
+        if (drag && drag.entityId && drag.field != null) {
+          next.set(remoteEditKey(drag.entityId, drag.field), drag)
+        }
+      })
+      setRemoteEdits(next)
+    }
+
+    // Initial read
+    update()
+    awareness.on('change', update)
+    return () => {
+      awareness.off('change', update)
+    }
+  }, [awareness])
+
+  return { broadcastEditing, clearEditing, remoteEdits }
+}
+
+/**
+ * Get a remote edit for a specific entity + field (resource index).
+ * Returns null if no remote user is currently editing.
+ */
+export function getRemoteEdit(
+  remoteEdits: RemoteEditMap,
+  entityId: string,
+  field: string,
+): AwarenessResourceState | null {
+  return remoteEdits.get(remoteEditKey(entityId, field)) ?? null
+}

--- a/src/shared/ui/ResourceBar.tsx
+++ b/src/shared/ui/ResourceBar.tsx
@@ -12,6 +12,16 @@ interface ResourceBarProps {
   draggable?: boolean
   showButtons?: boolean
   onChange?: (newCurrent: number) => void
+  /** Called when pointer-drag begins */
+  onDragStart?: () => void
+  /** Called on every move during drag (for awareness broadcast, NOT Yjs write) */
+  onDragMove?: (value: number) => void
+  /** Called on pointerUp to commit the final drag value (Yjs write) */
+  onDragEnd?: (value: number) => void
+  /** If a remote user is dragging this bar, display their live value */
+  remoteDragValue?: number | null
+  /** Soft-lock indicator color — shown when a remote user is editing */
+  softLockColor?: string | null
   className?: string
   style?: React.CSSProperties
 }
@@ -27,14 +37,26 @@ export function ResourceBar({
   draggable = false,
   showButtons = false,
   onChange,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  remoteDragValue,
+  softLockColor,
   className,
   style,
 }: ResourceBarProps) {
   const [isDragging, setIsDragging] = useState(false)
+  const [localDragValue, setLocalDragValue] = useState<number | null>(null)
   const barRef = useRef<HTMLDivElement>(null)
 
+  // Determine displayed value: local drag > remote drag > committed
+  const displayValue =
+    localDragValue != null ? localDragValue : remoteDragValue != null ? remoteDragValue : current
+
   const handleBarDrag = (e: React.PointerEvent) => {
-    if (!draggable || !onChange) return
+    if (!draggable) return
+    // Need at least one of: onChange, onDragEnd
+    if (!onChange && !onDragEnd) return
     e.preventDefault()
     e.stopPropagation()
 
@@ -43,25 +65,53 @@ export function ResourceBar({
 
     const rect = bar.getBoundingClientRect()
 
-    const onMove = (moveEvent: PointerEvent) => {
-      const x = moveEvent.clientX
-      const ratio = Math.max(0, Math.min(1, (x - rect.left) / rect.width))
-      const newValue = Math.round(ratio * max)
-      onChange(newValue)
+    const computeValue = (clientX: number) => {
+      const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+      return Math.round(ratio * max)
     }
 
-    const onUp = () => {
+    const onMove = (moveEvent: PointerEvent) => {
+      const newValue = computeValue(moveEvent.clientX)
+      setLocalDragValue(newValue)
+      // If awareness-aware: broadcast via onDragMove only
+      if (onDragMove) {
+        onDragMove(newValue)
+      }
+      // If NOT awareness-aware (legacy): write on every move
+      if (!onDragMove && !onDragEnd && onChange) {
+        onChange(newValue)
+      }
+    }
+
+    const onUp = (upEvent: PointerEvent) => {
+      const finalValue = computeValue(upEvent.clientX)
       setIsDragging(false)
+      setLocalDragValue(null)
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
+
+      // Commit final value
+      if (onDragEnd) {
+        onDragEnd(finalValue)
+      } else if (onChange) {
+        onChange(finalValue)
+      }
     }
 
     setIsDragging(true)
+    onDragStart?.()
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
 
     // immediate update
-    onMove(e.nativeEvent)
+    const initialValue = computeValue(e.nativeEvent.clientX)
+    setLocalDragValue(initialValue)
+    if (onDragMove) {
+      onDragMove(initialValue)
+    }
+    if (!onDragMove && !onDragEnd && onChange) {
+      onChange(initialValue)
+    }
   }
 
   const handleIncrement = () => {
@@ -74,9 +124,12 @@ export function ResourceBar({
     onChange(Math.max(current - 1, 0))
   }
 
-  const percentage = max > 0 ? (current / max) * 100 : 0
+  const percentage = max > 0 ? (displayValue / max) * 100 : 0
   const radius = Math.min(height / 2, 8)
   const inlineFontSize = Math.max(8, height * 0.5)
+
+  // Soft lock: show ring when a remote user is editing
+  const isRemoteLocked = !!softLockColor && !isDragging
 
   return (
     <div
@@ -102,8 +155,8 @@ export function ResourceBar({
         >
           {showLabel && <span>{label}</span>}
           {valueDisplay === 'outside' && (
-            <span style={{ color }}>
-              {current} / {max}
+            <span style={{ color: isRemoteLocked ? softLockColor! : color }}>
+              {displayValue} / {max}
             </span>
           )}
         </div>
@@ -132,6 +185,10 @@ export function ResourceBar({
             cursor: draggable ? 'ew-resize' : 'default',
             flex: showButtons ? 1 : undefined,
             width: showButtons ? undefined : '100%',
+            // Soft lock ring
+            boxShadow: isRemoteLocked
+              ? `0 0 0 2px ${softLockColor}, 0 0 8px ${softLockColor}66`
+              : undefined,
           }}
         >
           {/* Fill */}
@@ -143,7 +200,7 @@ export function ResourceBar({
               height: '100%',
               width: `${percentage}%`,
               background: `linear-gradient(90deg, ${color}, ${color}cc)`,
-              transition: isDragging ? 'none' : 'width 0.2s ease',
+              transition: isDragging || remoteDragValue != null ? 'none' : 'width 0.2s ease',
             }}
           />
 
@@ -166,8 +223,26 @@ export function ResourceBar({
                 pointerEvents: 'none',
               }}
             >
-              {current} / {max}
+              {displayValue} / {max}
             </div>
+          )}
+
+          {/* Soft lock dot indicator (top-right) */}
+          {isRemoteLocked && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 2,
+                right: 2,
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: softLockColor!,
+                boxShadow: `0 0 4px ${softLockColor}`,
+                pointerEvents: 'none',
+                zIndex: 1,
+              }}
+            />
           )}
         </div>
 

--- a/src/stores/identityStore.ts
+++ b/src/stores/identityStore.ts
@@ -38,8 +38,9 @@ interface IdentityState {
   _ySeats: Y.Map<Seat> | null
   _awareness: Awareness | null
 
-  // Derived getter
+  // Derived getters
   getMySeat: () => Seat | null
+  getAwareness: () => Awareness | null
 
   // Init — connects Yjs observer + awareness listener
   init: (ySeats: Y.Map<unknown>, awareness: Awareness | null) => () => void
@@ -65,6 +66,8 @@ export const useIdentityStore = create<IdentityState>((set, get) => ({
     if (!mySeatId || !_ySeats) return null
     return _ySeats.get(mySeatId) ?? null
   },
+
+  getAwareness: () => get()._awareness,
 
   init: (ySeats: Y.Map<unknown>, awareness: Awareness | null) => {
     const yPlayers = ySeats as Y.Map<Seat>


### PR DESCRIPTION
## Summary
- New `useAwarenessResource` hook broadcasts resource drags via Yjs awareness (~20fps)
- ResourceBar shows live remote drag values and colored soft-lock ring when another user edits
- CharacterEditPanel and CharacterHoverPreview display remote editing indicators
- Added `getAwareness` getter to identityStore

## Test plan
- [x] 0 TypeScript errors
- [x] 213 tests pass
- [ ] Verify resource drag broadcasts to other clients in real-time
- [ ] Verify soft lock ring appears when another user drags a resource bar