### PR TITLE
feat: enhance dust particle effect visibility

### DIFF
--- a/src/scene/particles.ts
+++ b/src/scene/particles.ts
@@ -34,13 +34,13 @@ export const PRESETS: Record<string, ParticlePresetConfig> = {
     shape: 'circle',
   },
   dust: {
-    count: 60,
+    count: 90,
     colors: ['#b0a890', '#c8b898', '#a09880', '#d0c8b0', '#908878'],
-    sizeRange: [0.8, 2.5],
+    sizeRange: [1.2, 3.5],
     speedRange: [0.1, 0.4],
     direction: { x: [-0.5, 0.5], y: [-0.3, 0.3] },
-    opacityRange: [0.15, 0.5],
-    glow: false,
+    opacityRange: [0.25, 0.65],
+    glow: true,
     shape: 'circle',
   },
   rain: {


### PR DESCRIPTION
## Summary
- 提升 dust 粒子特效的可见度（用户反馈原效果过于微弱）
- 增加粒子数量：60 → 90
- 增大粒子尺寸范围：[0.8, 2.5] → [1.2, 3.5]
- 提升不透明度范围：[0.15, 0.5] → [0.25, 0.65]  
- 启用发光效果

## Test plan
- [x] 在场景设置中启用 dust 粒子效果
- [x] 确认粒子特效明显可见
- [x] TypeScript 编译通过
- [x] 测试通过（213 个）