### PR TITLE
fix: post-PR45 code review fixes

### DIFF
--- a/src/combat/KonvaMap.tsx
+++ b/src/combat/KonvaMap.tsx
@@ -559,17 +559,7 @@ export function KonvaMap({
       )}
 
       {/* Zoom helper controls — HTML overlay */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 8,
-          right: 8,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 4,
-          zIndex: 10,
-        }}
-      >
+      <div className="absolute top-2 right-2 flex flex-col gap-1 z-10">
         <ZoomButton label="+" onClick={handleZoomIn} title="Zoom in" />
         <ZoomButton label="\u2212" onClick={handleZoomOut} title="Zoom out" />
         <ZoomButton label="\u2922" onClick={handleFitToWindow} title="Fit to window" />
@@ -696,23 +686,8 @@ function ZoomButton({
     <button
       onClick={onClick}
       title={title}
-      style={{
-        width: 28,
-        height: 28,
-        borderRadius: 4,
-        border: '1px solid rgba(180,160,130,0.15)',
-        background: 'rgba(20,15,12,0.88)',
-        color: '#F0E6D8',
-        fontSize: 16,
-        fontWeight: 700,
-        cursor: 'pointer',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: 0,
-        lineHeight: 1,
-        backdropFilter: 'blur(8px)',
-      }}
+      aria-label={title}
+      className="w-7 h-7 rounded flex items-center justify-center p-0 leading-none text-base font-bold cursor-pointer border border-border-glass bg-glass backdrop-blur-[8px] text-text-primary hover:bg-hover transition-colors duration-fast"
     >
       {label}
     </button>

--- a/src/combat/TacticalPanel.tsx
+++ b/src/combat/TacticalPanel.tsx
@@ -39,12 +39,11 @@ export function TacticalPanel({
 
   return (
     <div
-      className={`z-combat motion-reduce:duration-0 ${
+      className={`fixed inset-0 z-combat motion-reduce:duration-0 ${
         visible
           ? 'opacity-100 transition-opacity duration-slow ease-out pointer-events-auto'
           : 'opacity-0 transition-opacity duration-normal ease-in pointer-events-none'
       }`}
-      style={{ position: 'fixed', inset: 0 }}
       onContextMenu={visible ? onContextMenu : undefined}
     >
       {/* Screen-space vignette overlay — edge darkening for immersive map/background blending */}

--- a/src/combat/tools/GridConfigPanel.tsx
+++ b/src/combat/tools/GridConfigPanel.tsx
@@ -48,20 +48,14 @@ export function GridConfigPanel({ scene, onUpdateScene, onClose }: GridConfigPan
   return (
     <div
       ref={panelRef}
-      className="bg-glass backdrop-blur-[12px] border border-border-glass rounded-lg shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
-      style={{
-        position: 'fixed',
-        bottom: GM_TOOLBAR_HEIGHT,
-        left: 12,
-        width: 200,
-        zIndex: 10001, // above GmToolbar (z-toast: 10000)
-        padding: '12px',
-      }}
+      className="fixed left-3 w-[200px] p-3 z-popover bg-glass backdrop-blur-[12px] border border-border-glass rounded-lg shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
+      style={{ bottom: GM_TOOLBAR_HEIGHT }}
     >
       <div className="text-text-primary text-xs font-medium mb-3">Grid Settings</div>
 
-      <FieldRow label="Cell Size">
+      <FieldRow label="Cell Size" htmlFor="grid-cell-size">
         <NumberInput
+          id="grid-cell-size"
           value={gridSize}
           min={10}
           max={500}
@@ -72,8 +66,9 @@ export function GridConfigPanel({ scene, onUpdateScene, onClose }: GridConfigPan
         />
       </FieldRow>
 
-      <FieldRow label="Offset X">
+      <FieldRow label="Offset X" htmlFor="grid-offset-x">
         <NumberInput
+          id="grid-offset-x"
           value={gridOffsetX}
           min={-500}
           max={500}
@@ -84,8 +79,9 @@ export function GridConfigPanel({ scene, onUpdateScene, onClose }: GridConfigPan
         />
       </FieldRow>
 
-      <FieldRow label="Offset Y">
+      <FieldRow label="Offset Y" htmlFor="grid-offset-y">
         <NumberInput
+          id="grid-offset-y"
           value={gridOffsetY}
           min={-500}
           max={500}
@@ -96,8 +92,9 @@ export function GridConfigPanel({ scene, onUpdateScene, onClose }: GridConfigPan
         />
       </FieldRow>
 
-      <FieldRow label="Color">
+      <FieldRow label="Color" htmlFor="grid-color">
         <input
+          id="grid-color"
           type="color"
           value={gridColor}
           onChange={(e) => {
@@ -113,21 +110,33 @@ export function GridConfigPanel({ scene, onUpdateScene, onClose }: GridConfigPan
 
 // ── Helpers ──
 
-function FieldRow({ label, children }: { label: string; children: React.ReactNode }) {
+function FieldRow({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  children: React.ReactNode
+}) {
   return (
     <div className="flex items-center justify-between mb-2">
-      <span className="text-text-muted text-xs">{label}</span>
+      <label htmlFor={htmlFor} className="text-text-muted text-xs">
+        {label}
+      </label>
       {children}
     </div>
   )
 }
 
 function NumberInput({
+  id,
   value,
   min,
   max,
   onChange,
 }: {
+  id: string
   value: number
   min: number
   max: number
@@ -135,6 +144,7 @@ function NumberInput({
 }) {
   return (
     <input
+      id={id}
       type="number"
       value={value}
       min={min}

--- a/src/dock/MapDockTab.tsx
+++ b/src/dock/MapDockTab.tsx
@@ -107,12 +107,17 @@ export function MapDockTab({
           return (
             <div
               key={scene.id}
+              role="button"
+              tabIndex={0}
               className={`relative cursor-pointer rounded-lg overflow-hidden border-2 transition-all duration-fast ${
                 isActive
                   ? 'border-accent shadow-[0_0_12px_rgba(212,160,85,0.3)]'
                   : 'border-border-glass'
               }`}
               onClick={() => onSelectScene(scene.id)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') onSelectScene(scene.id)
+              }}
               onContextMenu={(e) => {
                 e.preventDefault()
                 setContextMenu({ sceneId: scene.id, x: e.clientX, y: e.clientY })
@@ -151,6 +156,7 @@ export function MapDockTab({
               {/* Delete button on hover */}
               {isHovered && (
                 <button
+                  aria-label="Delete scene"
                   onClick={(e) => {
                     e.stopPropagation()
                     onDeleteScene(scene.id)
@@ -165,20 +171,21 @@ export function MapDockTab({
         })}
 
         {/* Upload card */}
-        <div
+        <button
+          type="button"
           onClick={() => fileRef.current?.click()}
-          className="rounded-lg border-2 border-dashed border-border-glass cursor-pointer flex flex-col items-center justify-center gap-1 text-text-muted/30 transition-colors duration-fast hover:border-text-muted/30 hover:text-text-muted/50"
+          className="rounded-lg border-2 border-dashed border-border-glass cursor-pointer flex flex-col items-center justify-center gap-1 text-text-muted/30 transition-colors duration-fast hover:border-text-muted/30 hover:text-text-muted/50 bg-transparent"
           style={{ height: 94 }}
         >
           {uploading ? (
-            <span className="text-[11px]">Uploading...</span>
+            <span className="text-[11px]">Uploading…</span>
           ) : (
             <>
               <Plus size={20} strokeWidth={1.5} />
               <span className="text-[10px]">Add Map</span>
             </>
           )}
-        </div>
+        </button>
       </div>
 
       {/* Right-click context menu — portaled to body to escape CSS transform stacking context */}
@@ -188,7 +195,7 @@ export function MapDockTab({
           if (!scene) return null
           return createPortal(
             <div
-              className="fixed z-[10002] bg-glass backdrop-blur-[12px] border border-border-glass rounded-lg py-1 shadow-[0_4px_16px_rgba(0,0,0,0.4)]"
+              className="fixed z-popover bg-glass backdrop-blur-[12px] border border-border-glass rounded-lg py-1 shadow-[0_4px_16px_rgba(0,0,0,0.4)]"
               style={{ left: contextMenu.x, top: contextMenu.y }}
               onPointerDown={(e) => e.stopPropagation()}
             >

--- a/src/gm/GmToolbar.tsx
+++ b/src/gm/GmToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import {
   Image,
@@ -23,12 +23,12 @@ interface GmToolbarProps {
   scenes: Scene[]
   activeSceneId: string | null
   isCombat: boolean
-  activeScene: Scene | null // ← new
+  activeScene: Scene | null
   onSelectScene: (sceneId: string) => void
   onToggleCombat: () => void
   onUpdateScene: (id: string, updates: Partial<Scene>) => void
   onDeleteScene: (id: string) => void
-  onAdvanceInitiative: () => void // ← new
+  onAdvanceInitiative: () => void
 }
 
 type RangeSubTool = 'range-circle' | 'range-cone' | 'range-rect'
@@ -54,6 +54,7 @@ export function GmToolbar({
   const [showSceneList, setShowSceneList] = useState(false)
   const [editingSceneId, setEditingSceneId] = useState<string | null>(null)
   const [showGridConfig, setShowGridConfig] = useState(false)
+  const [showRangeMenu, setShowRangeMenu] = useState(false)
 
   const activeTool = useUiStore((s) => s.activeTool)
   const setActiveTool = useUiStore((s) => s.setActiveTool)
@@ -64,18 +65,32 @@ export function GmToolbar({
 
   const handleToggleGrid = () => {
     if (!activeScene) return
+    const next = !activeScene.gridVisible
     onUpdateScene(activeScene.id, {
-      gridVisible: !activeScene.gridVisible,
-      gridSnap: !activeScene.gridSnap,
+      gridVisible: next,
+      gridSnap: next,
     })
   }
 
   const isRangeActive = isRangeTool(activeTool)
 
+  // Close range submenu when switching away from range tools
+  useEffect(() => {
+    if (!isRangeActive) setShowRangeMenu(false)
+  }, [isRangeActive])
+
+  // Close range submenu on click outside toolbar
+  useEffect(() => {
+    if (!showRangeMenu) return
+    const close = () => setShowRangeMenu(false)
+    document.addEventListener('pointerdown', close)
+    return () => document.removeEventListener('pointerdown', close)
+  }, [showRangeMenu])
+
   return (
     <>
       <div
-        className="fixed bottom-3 left-4 z-toast flex flex-col gap-1.5 font-sans"
+        className="fixed bottom-3 left-4 z-ui flex flex-col gap-1.5 font-sans"
         onPointerDown={(e) => e.stopPropagation()}
       >
         {/* Upper row: tactical tools (only when isCombat) */}
@@ -96,28 +111,33 @@ export function GmToolbar({
               onClick={() => setActiveTool('measure')}
             />
             {/* Range with upward-opening submenu */}
-            <div className="relative group">
+            <div className="relative">
               <TacticalToolBtn
                 icon={<Circle size={16} strokeWidth={1.5} />}
                 active={isRangeActive}
                 title="Range templates"
-                onClick={() => setActiveTool(isRangeActive ? 'select' : 'range-circle')}
+                onClick={() => setShowRangeMenu((v) => !v)}
               />
-              <div className="absolute bottom-full left-0 mb-1 hidden group-hover:flex flex-col bg-glass backdrop-blur-[12px] border border-border-glass rounded py-1 z-10 min-w-[90px]">
-                {RANGE_TOOLS.map((tool) => (
-                  <button
-                    key={tool}
-                    onClick={() => setActiveTool(tool)}
-                    className={`px-2.5 py-1.5 text-xs text-left border-none cursor-pointer transition-colors duration-fast ${
-                      activeTool === tool
-                        ? 'bg-accent text-deep'
-                        : 'bg-transparent text-text-muted hover:text-text-primary hover:bg-hover'
-                    }`}
-                  >
-                    {RANGE_LABELS[tool]}
-                  </button>
-                ))}
-              </div>
+              {showRangeMenu && (
+                <div className="absolute bottom-full left-0 mb-1 flex flex-col bg-glass backdrop-blur-[12px] border border-border-glass rounded py-1 z-popover min-w-[90px]">
+                  {RANGE_TOOLS.map((tool) => (
+                    <button
+                      key={tool}
+                      onClick={() => {
+                        setActiveTool(tool)
+                        setShowRangeMenu(false)
+                      }}
+                      className={`px-2.5 py-1.5 text-xs text-left border-none cursor-pointer transition-colors duration-fast ${
+                        activeTool === tool
+                          ? 'bg-accent text-deep'
+                          : 'bg-transparent text-text-muted hover:text-text-primary hover:bg-hover'
+                      }`}
+                    >
+                      {RANGE_LABELS[tool]}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Separator */}
@@ -247,6 +267,7 @@ function TacticalToolBtn({
     <button
       onClick={onClick}
       title={title}
+      aria-label={title}
       className={`w-8 h-8 flex items-center justify-center rounded cursor-pointer border-none transition-colors duration-fast focus:ring-2 focus:ring-accent focus:outline-none ${
         active
           ? 'bg-accent text-deep'

--- a/src/scene/SceneViewer.tsx
+++ b/src/scene/SceneViewer.tsx
@@ -39,12 +39,11 @@ export function SceneViewer({ scene, blurred = false, onContextMenu }: SceneView
 
   const blurOverlay = (
     <div
-      className={`absolute inset-0 z-10 pointer-events-none motion-reduce:duration-0 ${
+      className={`absolute inset-0 z-10 pointer-events-none motion-reduce:duration-0 backdrop-blur-[8px] bg-deep/50 ${
         blurred
           ? 'opacity-100 transition-opacity duration-slow ease-out'
           : 'opacity-0 transition-opacity duration-normal ease-in'
       }`}
-      style={{ backdropFilter: 'blur(8px)', background: 'rgba(8,5,18,0.52)' }}
     />
   )
 
@@ -67,13 +66,7 @@ export function SceneViewer({ scene, blurred = false, onContextMenu }: SceneView
   return (
     <div
       onContextMenu={onContextMenu}
-      className="bg-deep"
-      style={{
-        width: '100vw',
-        height: '100vh',
-        position: 'relative',
-        overflow: 'hidden',
-      }}
+      className="bg-deep w-screen h-screen relative overflow-hidden"
     >
       {/* Combat blur + darken overlay — always rendered, opacity transition for smooth enter/exit */}
       {blurOverlay}


### PR DESCRIPTION
## 概述

PR #45（战术地图沉浸层）代码审查后续修复，覆盖 z-index、无障碍、touch 可用性、内联样式 4 个问题域。

- **z-index 根因修复**：`GmToolbar` 从 `z-toast`（10000）降至 `z-ui`（1000），消除 `GridConfigPanel`（`z-10001`）和 `MapDockTab` 右键菜单（`z-10002`）的 magic number，改用语义层 `z-popover`（5000）
- **`handleToggleGrid` 逻辑 bug**：双重取反改为 `const next = !gridVisible; gridSnap = next`，避免两字段不同步时产生矛盾状态
- **Range 子菜单 touch 可用性**：`hidden group-hover:flex` 改为 `showRangeMenu` state 控制，支持触摸设备；点击选项后自动关闭，点击外部（document pointerdown）或切换其他工具（isRangeActive effect）均关闭
- **无障碍**：`TacticalToolBtn` / `ZoomButton` 增加 `aria-label={title}`；MapDockTab 删除按钮增加 `aria-label`；上传卡片 `div` → `button`；场景卡片增加 `role="button"` + `tabIndex` + `onKeyDown`；GridConfigPanel 表单输入用 `<label htmlFor>` 正确关联
- **内联样式清理**：SceneViewer blur overlay 的硬编码 `rgba` 改用 `bg-deep/50 backdrop-blur-[8px]`；SceneViewer / TacticalPanel 定位样式转 Tailwind；KonvaMap ZoomButton 全套 inline styles 转 design tokens；GridConfigPanel 位置样式转 Tailwind
- **细节**：删除 `GmToolbar` 中的 `// ← new` 脚手架注释；`Uploading...` → `Uploading…`

## 测试计划

- [ ] 进入/退出战术模式，blur overlay 正常渐变，无双重渲染
- [ ] 主题切换（Warm/Cold），blur overlay 颜色响应主题
- [ ] Range 子菜单在 Chrome DevTools 触摸模拟下可点击展开
- [ ] Grid Toggle：`gridVisible` 与 `gridSnap` 始终保持一致
- [ ] GmToolbar、GridConfigPanel、右键菜单 z-index 无遮挡异常
- [ ] ZoomButton 外观与 dark glass 主题一致
- [ ] 键盘 Tab 聚焦 TacticalToolBtn 有可见 focus ring
- [ ] 全回归：Token 拖拽、右键菜单、场景切换正常