### PR TITLE
docs: add PR merge consent requirement to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,12 @@ All styling uses **Tailwind CSS v4**. Do NOT write inline styles.
 - PRs MUST be merged using **squash merge** (`gh pr merge --squash`) — never use merge commits or rebase merge
 - This keeps `main` clean: one commit per PR, no merge bubbles
 
+**Merge requires explicit user consent (IMPORTANT):**
+
+- **NEVER merge a PR** without the user explicitly saying so (e.g. "merge", "合并", "merge the PR")
+- Creating a PR and merging a PR are two separate steps — do NOT merge immediately after creating
+- After creating a PR, stop and wait for the user to review and give the go-ahead
+
 **Worktree conventions:**
 
 - Worktree directory: `.worktrees/<branch-name>` (already in `.gitignore`)


### PR DESCRIPTION
## 概述

在 CLAUDE.md Git 工作流章节中补充明确规则：**创建 PR 和合并 PR 是两个独立步骤**，未经用户明确指示不得自动合并。

## 变更内容

在 `squash merge only` 说明之后新增：

> **Merge requires explicit user consent (IMPORTANT):**
> - NEVER merge a PR without the user explicitly saying so (e.g. "merge", "合并", "merge the PR")
> - Creating a PR and merging a PR are two separate steps — do NOT merge immediately after creating
> - After creating a PR, stop and wait for the user to review and give the go-ahead