### PR TITLE
fix: right-click NPC/token creation in scene and tactical mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,6 @@ import { ContextMenu } from './shared/ContextMenu'
 import { ShowcaseOverlay } from './showcase/ShowcaseOverlay'
 import type { ShowcaseItem } from './showcase/showcaseTypes'
 import type { Entity, Atmosphere, SceneEntityEntry } from './shared/entityTypes'
-import { defaultNPCPermissions } from './shared/permissions'
 import { HandoutEditModal } from './dock/HandoutEditModal'
 import { generateTokenId } from './shared/idUtils'
 import { TeamDashboard } from './team/TeamDashboard'
@@ -178,9 +177,7 @@ function RoomSession({ roomId }: { roomId: string }) {
   }
 
   const activeEntity = getEntity(mySeat?.activeCharacterId ?? null)
-  const selectedToken = isTactical
-    ? (tokens.find((t) => t.id === selectedTokenId) ?? null)
-    : null
+  const selectedToken = isTactical ? (tokens.find((t) => t.id === selectedTokenId) ?? null) : null
   const selectedTokenEntity = selectedToken?.entityId ? getEntity(selectedToken.entityId) : null
 
   const seatProperties = deriveSeatProperties(activeEntity, selectedTokenEntity)
@@ -329,22 +326,13 @@ function RoomSession({ roomId }: { roomId: string }) {
   }
 
   const handleAddNpc = () => {
-    const newEntity: Entity = {
-      id: generateTokenId(),
-      name: 'New NPC',
-      imageUrl: '',
-      color: '#3b82f6',
-      width: 1,
-      height: 1,
-      notes: '',
-      ruleData: null,
-      permissions: defaultNPCPermissions(),
-      lifecycle: 'ephemeral',
-    }
-    handleAddEntity(newEntity)
-    if (room.activeSceneId) addEntityToScene(room.activeSceneId, newEntity.id)
-    setInspectedCharacterId(newEntity.id)
     setBgContextMenu(null)
+    void useWorldStore
+      .getState()
+      .createEphemeralNpcInScene()
+      .then((entity) => {
+        if (entity) setInspectedCharacterId(entity.id)
+      })
   }
 
   const handleDropEntityOnMap = (entityId: string, mapX: number, mapY: number) => {

--- a/src/combat/KonvaMap.tsx
+++ b/src/combat/KonvaMap.tsx
@@ -162,6 +162,9 @@ export function KonvaMap({
       // Only handle right-click on empty space (stage/layer), not on tokens
       if (!isStage && !isLayer) return
 
+      // Stop DOM propagation so the App-level context menu doesn't also open
+      e.evt.stopPropagation()
+
       const pointer = stage?.getRelativePointerPosition()
       if (!pointer) return
 
@@ -203,7 +206,7 @@ export function KonvaMap({
     setContextMenu(null)
   }, [])
 
-  // Create token on empty space
+  // Create token on empty space — spawns an ephemeral entity + tactical token
   const handleCreateToken = useCallback(
     (mapX: number, mapY: number) => {
       if (!tacticalInfo) return
@@ -220,10 +223,7 @@ export function KonvaMap({
         x = snapped.x
         y = snapped.y
       }
-      // Token creation from empty space is no longer supported —
-      // all tokens must be linked to an entity. Drag an entity from the portrait bar instead.
-      void x
-      void y
+      void useWorldStore.getState().spawnEphemeralTokenAtPosition(x, y)
     },
     [tacticalInfo],
   )

--- a/src/stores/worldStore.ts
+++ b/src/stores/worldStore.ts
@@ -8,6 +8,8 @@ import type { Entity, MapToken, Atmosphere, SceneEntityEntry } from '../shared/e
 import type { ShowcaseItem } from '../showcase/showcaseTypes'
 import type { ChatMessage } from '../chat/chatTypes'
 import { api } from '../shared/api'
+import { generateTokenId } from '../shared/idUtils'
+import { defaultNPCPermissions } from '../shared/permissions'
 
 // ── Types ──
 
@@ -145,13 +147,12 @@ interface WorldState {
   addEntity: (entity: Entity) => Promise<void>
   updateEntity: (id: string, updates: Partial<Entity>) => Promise<void>
   deleteEntity: (id: string) => Promise<void>
+  // Composed actions — multi-step orchestration
+  createEphemeralNpcInScene: () => Promise<Entity | null>
+  spawnEphemeralTokenAtPosition: (x: number, y: number) => Promise<Entity | null>
 
   // Token actions
-  createToken: (
-    x: number,
-    y: number,
-    opts?: { name?: string; color?: string },
-  ) => Promise<void>
+  createToken: (x: number, y: number, opts?: { name?: string; color?: string }) => Promise<void>
   placeEntityOnMap: (entityId: string, x: number, y: number) => Promise<void>
   duplicateToken: (tokenId: string, offsetX?: number, offsetY?: number) => Promise<void>
   addToken: (token: MapToken) => Promise<void>
@@ -708,6 +709,77 @@ export const useWorldStore = create<WorldState>((set, get) => ({
     const roomId = get()._roomId
     if (!roomId) return
     await api.delete(`/api/rooms/${roomId}/entities/${id}`)
+  },
+
+  createEphemeralNpcInScene: async () => {
+    const roomId = get()._roomId
+    if (!roomId) return null
+    const sceneId = get().room.activeSceneId
+    const entity: Entity = {
+      id: generateTokenId(),
+      name: 'New NPC',
+      imageUrl: '',
+      color: '#3b82f6',
+      width: 1,
+      height: 1,
+      notes: '',
+      ruleData: null,
+      permissions: defaultNPCPermissions(),
+      lifecycle: 'ephemeral',
+    }
+    // Optimistic update so character card can open immediately
+    set((s) => ({
+      entities: { ...s.entities, [entity.id]: entity },
+      ...(sceneId
+        ? {
+            sceneEntityMap: {
+              ...s.sceneEntityMap,
+              [sceneId]: [
+                ...(s.sceneEntityMap[sceneId] ?? []),
+                { entityId: entity.id, visible: true },
+              ],
+            },
+          }
+        : {}),
+    }))
+    await api.post(`/api/rooms/${roomId}/entities`, entity)
+    if (sceneId) await api.post(`/api/rooms/${roomId}/scenes/${sceneId}/entities/${entity.id}`)
+    return entity
+  },
+
+  spawnEphemeralTokenAtPosition: async (x, y) => {
+    const roomId = get()._roomId
+    if (!roomId) return null
+    const sceneId = get().room.activeSceneId
+    if (!sceneId) return null
+    const entity: Entity = {
+      id: generateTokenId(),
+      name: 'New NPC',
+      imageUrl: '',
+      color: '#3b82f6',
+      width: 1,
+      height: 1,
+      notes: '',
+      ruleData: null,
+      permissions: defaultNPCPermissions(),
+      lifecycle: 'ephemeral',
+    }
+    // Optimistic update
+    set((s) => ({
+      entities: { ...s.entities, [entity.id]: entity },
+      sceneEntityMap: {
+        ...s.sceneEntityMap,
+        [sceneId]: [...(s.sceneEntityMap[sceneId] ?? []), { entityId: entity.id, visible: true }],
+      },
+    }))
+    await api.post(`/api/rooms/${roomId}/entities`, entity)
+    await api.post(`/api/rooms/${roomId}/scenes/${sceneId}/entities/${entity.id}`)
+    await api.post(`/api/rooms/${roomId}/tactical/tokens/from-entity`, {
+      entityId: entity.id,
+      x,
+      y,
+    })
+    return entity
   },
 
   toggleEntityVisibility: async (sceneId, entityId, visible) => {


### PR DESCRIPTION
## Summary

- **Narrative mode**: Right-click → Add NPC now works — entity and scene entry are optimistically added to the store before API calls complete, so the character card opens immediately
- **Tactical mode**: Fixed two issues — (1) \`e.evt.stopPropagation()\` prevents the Konva canvas right-click from also triggering the App-level NPC menu; (2) \"Create Token\" now creates an ephemeral entity + scene entry + tactical token at the clicked position
- **Socket.io / REST access control**: Enforced strict gating — both \`withRoom\` and \`setupSocketAuth\` now check the global \`rooms\` table first. Only rooms created via \`POST /api/rooms\` are accessible. Fixes silent real-time failure (\"战斗\" button appeared to do nothing) caused by the two middleware using different room-existence checks
- **Store Action Convention**: Extracted all inline upload handlers from components into named store methods (\`uploadAndUpdateEntityPortrait\`, \`uploadAndUpdateSeatPortrait\`, \`uploadAndAddHandout\`). Deleted dead \`SceneLibrary.tsx\`. Handout IDs now use server-assigned ID instead of client-generated UUID

## Root cause analysis

The \"战斗\" button bug was a split-brain: \`withRoom\` auto-created room DBs for any valid ID, but \`setupSocketAuth\` checked the global \`rooms\` table (only populated via \`POST /api/rooms\`). REST calls succeeded; Socket.io connections failed silently. All real-time state updates were lost.

Fix: both middleware now gate on the global \`rooms\` table. \`POST /api/rooms\` is the single entry point.

## Systemic prevention added

- **CLAUDE.md — Server Infrastructure Rule**: updated to document the strict-gating design intent
- **CLAUDE.md — Refactor PR Checklist**: grep for renamed strings, interface cleanup, browser verification
- **Regression tests**: \`socket-auth.test.ts\` verifies that unregistered rooms are rejected by both REST (404) and Socket.io, and that registered rooms receive real-time broadcasts end-to-end

## Test plan

- [ ] Narrative mode: right-click blank area → Add NPC → character card opens immediately
- [ ] Tactical mode: right-click blank map area → single menu → token appears on map
- [ ] \"战斗\" button enters tactical mode and broadcasts \`room:state:updated\` to all clients
- [ ] Navigating to an unregistered room URL returns a clear error (not silent partial failure)
- [ ] All 564 tests pass