### PR TITLE
docs: enforce no-direct-commit-on-main rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ React + Socket.io + SQLite VTT with dual-mode: Scene (atmosphere) + Tactical (co
 | Server   | Express 5.2, better-sqlite3 (per-room SQLite), Socket.io v4.8              |
 | Testing  | vitest v4 + @testing-library/react + jsdom                                 |
 
+## ⚠️ NEVER Commit Directly on main
+
+**All development MUST happen on a feature branch** (via worktree or `git checkout -b`). Do NOT commit, edit, or create files intended for commit on the `main` branch. Always create a branch first before writing any code. See [git-workflow.md](docs/conventions/git-workflow.md).
+
 ## ⚠️ MANDATORY — Required Reading Before You Code
 
 **STOP. Before writing any code, check the table below. If your task matches a trigger, you MUST read the linked document first. Do NOT skip this step.**


### PR DESCRIPTION
## Summary
- Add top-level `⚠️ NEVER Commit Directly on main` section to CLAUDE.md
- Placed above the mandatory reading table so it cannot be missed
- References existing `git-workflow.md` for full details

## Motivation
The rule already exists in `docs/conventions/git-workflow.md` but was only surfaced via the mandatory reading table (triggered by "Creating branches, committing, or opening PRs"). This made it easy to miss — code could be written on main before the branch/commit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)