### PR TITLE
fix: distinguish tactical objects from scene entities in combat mode

### DIFF
--- a/server/__tests__/scenarios/tactical-object-distinction.test.ts
+++ b/server/__tests__/scenarios/tactical-object-distinction.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { setupTestRoom, type TestContext } from '../helpers/test-server'
+
+let ctx: TestContext
+let sceneId: string
+
+beforeAll(async () => {
+  ctx = await setupTestRoom('tactical-object-distinction-test')
+
+  // Setup: create scene + set active
+  const { data: scene } = await ctx.api('POST', `/api/rooms/${ctx.roomId}/scenes`, {
+    name: 'Battle Arena',
+    atmosphere: {},
+  })
+  sceneId = (scene as { id: string }).id
+  await ctx.api('PATCH', `/api/rooms/${ctx.roomId}/state`, { activeSceneId: sceneId })
+})
+
+afterAll(async () => {
+  await ctx.cleanup()
+})
+
+describe('Tactical Object vs Scene Entity distinction', () => {
+  it('quick-create token does NOT create scene_entity_entry', async () => {
+    const { status, data } = await ctx.api(
+      'POST',
+      `/api/rooms/${ctx.roomId}/tactical/tokens/quick`,
+      { x: 1, y: 1, name: 'Goblin' },
+    )
+    expect(status).toBe(201)
+
+    const result = data as {
+      entity: { id: string; lifecycle: string }
+      token: { id: string; entityId: string }
+    }
+    expect(result.entity.lifecycle).toBe('ephemeral')
+    expect(result.token.entityId).toBe(result.entity.id)
+
+    // Verify entity is NOT in scene_entities
+    const { data: entries } = await ctx.api(
+      'GET',
+      `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities`,
+    )
+    const found = (entries as { entityId: string }[]).find((e) => e.entityId === result.entity.id)
+    expect(found).toBeUndefined()
+  })
+
+  describe('Blueprint spawn with tacticalOnly flag', () => {
+    let blueprintId: string
+
+    beforeAll(async () => {
+      // Create a blueprint asset
+      const formData = new FormData()
+      const blob = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' })
+      formData.append('file', blob, 'skeleton.png')
+      formData.append('name', 'Skeleton')
+      formData.append('type', 'blueprint')
+      formData.append(
+        'extra',
+        JSON.stringify({
+          blueprint: { defaultSize: 1, defaultColor: '#888888', defaultRuleData: {} },
+        }),
+      )
+
+      const res = await fetch(`${ctx.apiBase}/api/rooms/${ctx.roomId}/assets`, {
+        method: 'POST',
+        body: formData,
+      })
+      expect(res.status).toBe(201)
+      blueprintId = ((await res.json()) as { id: string }).id
+    })
+
+    it('spawn with tacticalOnly=true does NOT create scene_entity_entry', async () => {
+      const { status, data } = await ctx.api(
+        'POST',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/spawn`,
+        { blueprintId, tacticalOnly: true },
+      )
+      expect(status).toBe(201)
+
+      const result = data as {
+        entity: { id: string; name: string }
+        sceneEntity: null
+      }
+      expect(result.entity.name).toContain('Skeleton')
+      expect(result.sceneEntity).toBeNull()
+
+      // Verify entity is NOT in scene_entities
+      const { data: entries } = await ctx.api(
+        'GET',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities`,
+      )
+      const found = (entries as { entityId: string }[]).find((e) => e.entityId === result.entity.id)
+      expect(found).toBeUndefined()
+    })
+
+    it('spawn without tacticalOnly (default) DOES create scene_entity_entry', async () => {
+      const { status, data } = await ctx.api(
+        'POST',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/spawn`,
+        { blueprintId },
+      )
+      expect(status).toBe(201)
+
+      const result = data as {
+        entity: { id: string }
+        sceneEntity: { visible: boolean }
+      }
+      expect(result.sceneEntity).not.toBeNull()
+      expect(result.sceneEntity.visible).toBe(true)
+
+      // Verify entity IS in scene_entities
+      const { data: entries } = await ctx.api(
+        'GET',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities`,
+      )
+      const found = (entries as { entityId: string }[]).find((e) => e.entityId === result.entity.id)
+      expect(found).toBeDefined()
+    })
+  })
+
+  describe('Unlink ephemeral entity with/without tactical token', () => {
+    it('unlink ephemeral entity WITH tactical token keeps entity alive (demotion)', async () => {
+      // 1. Create entity
+      const entityId = 'e-demote01'
+      await ctx.api('POST', `/api/rooms/${ctx.roomId}/entities`, {
+        id: entityId,
+        name: 'Demotable NPC',
+        imageUrl: '',
+        color: '#ff0000',
+        width: 1,
+        height: 1,
+        lifecycle: 'ephemeral',
+      })
+
+      // 2. Link to scene
+      await ctx.api('POST', `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities/${entityId}`)
+
+      // 3. Create tactical token for this entity
+      await ctx.api('POST', `/api/rooms/${ctx.roomId}/tactical/tokens/from-entity`, {
+        entityId,
+        x: 5,
+        y: 5,
+      })
+
+      // 4. Unlink from scene (demote)
+      const { status } = await ctx.api(
+        'DELETE',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities/${entityId}`,
+      )
+      expect(status).toBe(200)
+
+      // 5. Verify scene_entity_entry is removed
+      const { data: entries } = await ctx.api(
+        'GET',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities`,
+      )
+      const found = (entries as { entityId: string }[]).find((e) => e.entityId === entityId)
+      expect(found).toBeUndefined()
+
+      // 6. Verify entity still exists (not deleted!)
+      const { status: entityStatus } = await ctx.api('GET', `/api/rooms/${ctx.roomId}/entities`)
+      expect(entityStatus).toBe(200)
+    })
+
+    it('unlink ephemeral entity WITHOUT tactical token deletes entity', async () => {
+      // 1. Create entity
+      const entityId = 'e-cleanup1'
+      await ctx.api('POST', `/api/rooms/${ctx.roomId}/entities`, {
+        id: entityId,
+        name: 'Cleanup NPC',
+        imageUrl: '',
+        color: '#00ff00',
+        width: 1,
+        height: 1,
+        lifecycle: 'ephemeral',
+      })
+
+      // 2. Link to scene
+      await ctx.api('POST', `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities/${entityId}`)
+
+      // 3. Unlink (no tactical token — should delete entity)
+      const { status } = await ctx.api(
+        'DELETE',
+        `/api/rooms/${ctx.roomId}/scenes/${sceneId}/entities/${entityId}`,
+      )
+      expect(status).toBe(200)
+
+      // 4. Verify entity is deleted
+      const { data: allEntities } = await ctx.api('GET', `/api/rooms/${ctx.roomId}/entities`)
+      const found = (allEntities as { id: string }[]).find((e) => e.id === entityId)
+      expect(found).toBeUndefined()
+    })
+  })
+})

--- a/server/routes/scenes.ts
+++ b/server/routes/scenes.ts
@@ -199,20 +199,26 @@ export function sceneRoutes(dataDir: string, io: Server): Router {
       .get(req.params.entityId) as { lifecycle: string } | undefined
     const isEphemeral = entity?.lifecycle === 'ephemeral'
 
+    // Keep ephemeral entities alive if they still have a tactical token (demotion case)
+    const hasTacticalToken = req
+      .roomDb!.prepare('SELECT 1 FROM tactical_tokens WHERE entity_id = ? LIMIT 1')
+      .get(req.params.entityId)
+    const shouldDeleteEntity = isEphemeral && !hasTacticalToken
+
     const unlinkEntity = req.roomDb!.transaction(() => {
       req
         .roomDb!.prepare('DELETE FROM scene_entities WHERE scene_id = ? AND entity_id = ?')
         .run(req.params.sceneId, req.params.entityId)
 
-      // If ephemeral, also delete the entity
-      if (isEphemeral) {
+      // Only delete ephemeral entities that have no tactical tokens
+      if (shouldDeleteEntity) {
         degradeTokenReferences(req.roomDb!, req.params.entityId as string)
         req.roomDb!.prepare('DELETE FROM entities WHERE id = ?').run(req.params.entityId)
       }
     })
     unlinkEntity()
 
-    if (isEphemeral) {
+    if (shouldDeleteEntity) {
       io.to(req.roomId!).emit('entity:deleted', { id: req.params.entityId })
     }
     io.to(req.roomId!).emit('scene:entity:unlinked', {
@@ -255,7 +261,7 @@ export function sceneRoutes(dataDir: string, io: Server): Router {
 
   // Spawn entity from blueprint
   router.post('/api/rooms/:roomId/scenes/:sceneId/spawn', room, (req, res) => {
-    const { blueprintId } = req.body as Record<string, unknown>
+    const { blueprintId, tacticalOnly } = req.body as Record<string, unknown>
     if (!blueprintId) {
       res.status(400).json({ error: 'blueprintId is required' })
       return
@@ -297,11 +303,14 @@ export function sceneRoutes(dataDir: string, io: Server): Router {
           blueprintId,
         )
 
-      req
-        .roomDb!.prepare(
-          'INSERT INTO scene_entities (scene_id, entity_id, visible) VALUES (?, ?, 1)',
-        )
-        .run(req.params.sceneId, entityId)
+      // Only create scene_entity_entry if NOT tactical-only (tactical objects skip this)
+      if (!tacticalOnly) {
+        req
+          .roomDb!.prepare(
+            'INSERT INTO scene_entities (scene_id, entity_id, visible) VALUES (?, ?, 1)',
+          )
+          .run(req.params.sceneId, entityId)
+      }
     })
     spawnEntity()
 
@@ -313,14 +322,16 @@ export function sceneRoutes(dataDir: string, io: Server): Router {
     )
 
     io.to(req.roomId!).emit('entity:created', entity)
-    io.to(req.roomId!).emit('scene:entity:linked', {
-      sceneId: req.params.sceneId,
-      entityId,
-      visible: true,
-    })
+    if (!tacticalOnly) {
+      io.to(req.roomId!).emit('scene:entity:linked', {
+        sceneId: req.params.sceneId,
+        entityId,
+        visible: true,
+      })
+    }
     res.status(201).json({
       entity,
-      sceneEntity: { sceneId: req.params.sceneId, entityId, visible: true },
+      sceneEntity: tacticalOnly ? null : { sceneId: req.params.sceneId, entityId, visible: true },
     })
   })
 

--- a/src/combat/KonvaMap.tsx
+++ b/src/combat/KonvaMap.tsx
@@ -225,7 +225,7 @@ export function KonvaMap({
         x = snapped.x
         y = snapped.y
       }
-      void useWorldStore.getState().spawnEphemeralTokenAtPosition(x, y)
+      void useWorldStore.getState().createToken(x, y)
     },
     [tacticalInfo],
   )

--- a/src/gm/EntityPanel.tsx
+++ b/src/gm/EntityPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Plus, Search, ClipboardList, Eye, EyeOff } from 'lucide-react'
+import { Plus, Search, ClipboardList, Eye, EyeOff, MapPin, Swords } from 'lucide-react'
 import type { Entity, SceneEntityEntry } from '../shared/entityTypes'
 import { defaultNPCPermissions } from '../shared/permissions'
 import { useWorldStore } from '../stores/worldStore'
@@ -10,14 +10,19 @@ import { generateTokenId } from '../shared/idUtils'
 import { EntityRow } from './EntityRow'
 
 const EMPTY_ENTRIES: SceneEntityEntry[] = []
+const EMPTY_TACTICAL: Entity[] = []
+
+type GroupType = 'onStage' | 'backstage' | 'tactical'
 
 export function EntityPanel() {
   const entities = useWorldStore((s) => s.entities)
   const activeSceneId = useWorldStore((s) => s.room.activeSceneId)
   const sceneEntityMap = useWorldStore((s) => s.sceneEntityMap)
+  const tacticalInfo = useWorldStore((s) => s.tacticalInfo)
   const addEntity = useWorldStore((s) => s.addEntity)
   const deleteEntity = useWorldStore((s) => s.deleteEntity)
   const addEntityToScene = useWorldStore((s) => s.addEntityToScene)
+  const removeEntityFromScene = useWorldStore((s) => s.removeEntityFromScene)
   const updateEntity = useWorldStore((s) => s.updateEntity)
   const toggleEntityVisibility = useWorldStore((s) => s.toggleEntityVisibility)
   const seats = useIdentityStore((s) => s.seats)
@@ -62,6 +67,22 @@ export function EntityPanel() {
     return { onStage: on, backstage: off }
   }, [sceneEntries, entities, pcIds, search])
 
+  // Tactical-only entities: have tokens but NO scene_entity_entry
+  const tacticalOnlyEntities = useMemo(() => {
+    if (!tacticalInfo) return EMPTY_TACTICAL
+    const sceneEntityIdSet = new Set(sceneEntries.map((e) => e.entityId))
+    const result: Entity[] = []
+    for (const token of tacticalInfo.tokens) {
+      if (sceneEntityIdSet.has(token.entityId)) continue
+      if (pcIds.has(token.entityId)) continue
+      const entity = entities[token.entityId]
+      if (!entity) continue
+      if (search && !entity.name.toLowerCase().includes(search.toLowerCase())) continue
+      result.push(entity)
+    }
+    return result
+  }, [tacticalInfo, sceneEntries, entities, pcIds, search])
+
   // Check online status per entity
   const getOnlineStatus = (entity: Entity): boolean => {
     for (const [seatId, perm] of Object.entries(entity.permissions.seats)) {
@@ -100,7 +121,26 @@ export function EntityPanel() {
     void toggleEntityVisibility(activeSceneId, entity.id, !currentlyVisible)
   }
 
-  const renderGroup = (title: string, icon: string, list: Entity[], isVisible: boolean) => {
+  // Promote tactical object → scene entity
+  const handlePromote = (entity: Entity) => {
+    if (!activeSceneId) return
+    void addEntityToScene(activeSceneId, entity.id)
+  }
+
+  // Demote scene entity → tactical object (only ephemeral entities with tokens)
+  const handleDemote = (entity: Entity) => {
+    if (!activeSceneId) return
+    void removeEntityFromScene(activeSceneId, entity.id)
+  }
+
+  // Check if entity can be demoted (ephemeral + has tactical token)
+  const canDemote = (entity: Entity): boolean => {
+    if (entity.lifecycle !== 'ephemeral') return false
+    if (!tacticalInfo) return false
+    return tacticalInfo.tokens.some((t) => t.entityId === entity.id)
+  }
+
+  const renderGroup = (title: string, icon: string, list: Entity[], groupType: GroupType) => {
     if (list.length === 0) return null
     return (
       <div className="mb-3">
@@ -130,21 +170,50 @@ export function EntityPanel() {
                   void updateEntity(entity.id, updates)
                 }}
               />
-              {/* Visibility toggle button */}
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleToggleVisibility(entity, isVisible)
-                }}
-                className="absolute right-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 text-text-muted/40 hover:text-text-primary p-0.5 cursor-pointer transition-opacity duration-fast"
-                title={isVisible ? '离场' : '上场'}
-              >
-                {isVisible ? (
-                  <Eye size={12} strokeWidth={1.5} />
-                ) : (
-                  <EyeOff size={12} strokeWidth={1.5} />
-                )}
-              </button>
+              {/* Action buttons based on group type */}
+              {groupType === 'tactical' ? (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handlePromote(entity)
+                  }}
+                  className="absolute right-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 text-text-muted/40 hover:text-accent p-0.5 cursor-pointer transition-opacity duration-fast"
+                  title="升级为场景角色"
+                >
+                  <MapPin size={12} strokeWidth={1.5} />
+                </button>
+              ) : (
+                <>
+                  {/* Visibility toggle for scene entities */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleToggleVisibility(entity, groupType === 'onStage')
+                    }}
+                    className="absolute right-7 opacity-0 group-hover:opacity-100 hover:!opacity-100 text-text-muted/40 hover:text-text-primary p-0.5 cursor-pointer transition-opacity duration-fast"
+                    title={groupType === 'onStage' ? '离场' : '上场'}
+                  >
+                    {groupType === 'onStage' ? (
+                      <Eye size={12} strokeWidth={1.5} />
+                    ) : (
+                      <EyeOff size={12} strokeWidth={1.5} />
+                    )}
+                  </button>
+                  {/* Demote button for ephemeral scene entities with tokens */}
+                  {canDemote(entity) && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        handleDemote(entity)
+                      }}
+                      className="absolute right-14 opacity-0 group-hover:opacity-100 hover:!opacity-100 text-text-muted/40 hover:text-accent p-0.5 cursor-pointer transition-opacity duration-fast"
+                      title="降级为战术对象"
+                    >
+                      <Swords size={12} strokeWidth={1.5} />
+                    </button>
+                  )}
+                </>
+              )}
             </div>
           ))}
         </div>
@@ -152,7 +221,8 @@ export function EntityPanel() {
     )
   }
 
-  const isEmpty = onStage.length === 0 && backstage.length === 0
+  const isEmpty =
+    onStage.length === 0 && backstage.length === 0 && tacticalOnlyEntities.length === 0
   const noResults = !isEmpty || search.trim().length > 0
 
   return (
@@ -184,12 +254,16 @@ export function EntityPanel() {
             <span className="opacity-50">暂无NPC</span>
             <span className="opacity-30 text-[10px] mt-1">点击下方「+」创建</span>
           </div>
-        ) : onStage.length === 0 && backstage.length === 0 && noResults ? (
+        ) : onStage.length === 0 &&
+          backstage.length === 0 &&
+          tacticalOnlyEntities.length === 0 &&
+          noResults ? (
           <div className="text-center text-text-muted/40 text-xs py-8">无匹配结果</div>
         ) : (
           <>
-            {renderGroup('在场', '\u25CF', onStage, true)}
-            {renderGroup('离场', '\u25D0', backstage, false)}
+            {renderGroup('在场', '\u25CF', onStage, 'onStage')}
+            {renderGroup('离场', '\u25D0', backstage, 'backstage')}
+            {renderGroup('战术对象', '\u2694', tacticalOnlyEntities, 'tactical')}
           </>
         )}
       </div>

--- a/src/gm/GmDock.tsx
+++ b/src/gm/GmDock.tsx
@@ -15,7 +15,6 @@ import {
 import type { MapToken, Entity, Blueprint, Atmosphere } from '../shared/entityTypes'
 import { useToast } from '../shared/ui/useToast'
 import { defaultNPCPermissions } from '../shared/permissions'
-import { generateTokenId } from '../shared/idUtils'
 import { useWorldStore } from '../stores/worldStore'
 import { MapDockTab } from '../dock/MapDockTab'
 import { BlueprintDockTab } from '../dock/BlueprintDockTab'
@@ -100,21 +99,12 @@ export function GmDock({
 
   const handleSpawnFromBlueprint = async (bp: Blueprint) => {
     if (!activeSceneId) return
-    const entity = await useWorldStore.getState().spawnFromBlueprint(activeSceneId, bp.id)
+    const entity = await useWorldStore.getState().spawnFromBlueprint(activeSceneId, bp.id, {
+      tacticalOnly: isTactical,
+    })
     if (!entity) return
     if (isTactical) {
-      const token: MapToken = {
-        id: generateTokenId(),
-        entityId: entity.id,
-        x: 200,
-        y: 200,
-        width: bp.defaultSize,
-        height: bp.defaultSize,
-        imageScaleX: 1,
-        imageScaleY: 1,
-      }
-      onAddToken(token)
-      onSelectToken(token.id)
+      void useWorldStore.getState().placeEntityOnMap(entity.id, 200, 200)
     }
   }
 

--- a/src/stores/worldStore.ts
+++ b/src/stores/worldStore.ts
@@ -129,7 +129,11 @@ interface WorldState {
   getSceneEntityEntries: (sceneId: string) => SceneEntityEntry[]
   toggleEntityVisibility: (sceneId: string, entityId: string, visible: boolean) => Promise<void>
   saveEntityAsBlueprint: (entity: Entity) => Promise<void>
-  spawnFromBlueprint: (sceneId: string, blueprintId: string) => Promise<Entity | null>
+  spawnFromBlueprint: (
+    sceneId: string,
+    blueprintId: string,
+    opts?: { tacticalOnly?: boolean },
+  ) => Promise<Entity | null>
   duplicateScene: (sourceId: string, newId: string) => Promise<void>
 
   // Archive actions
@@ -154,7 +158,6 @@ interface WorldState {
   deleteEntity: (id: string) => Promise<void>
   // Composed actions — multi-step orchestration
   createEphemeralNpcInScene: () => Promise<Entity | null>
-  spawnEphemeralTokenAtPosition: (x: number, y: number) => Promise<Entity | null>
 
   // Token actions
   createToken: (x: number, y: number, opts?: { name?: string; color?: string }) => Promise<void>
@@ -773,41 +776,6 @@ export const useWorldStore = create<WorldState>((set, get) => ({
     return entity
   },
 
-  spawnEphemeralTokenAtPosition: async (x, y) => {
-    const roomId = get()._roomId
-    if (!roomId) return null
-    const sceneId = get().room.activeSceneId
-    if (!sceneId) return null
-    const entity: Entity = {
-      id: generateTokenId(),
-      name: 'New NPC',
-      imageUrl: '',
-      color: '#3b82f6',
-      width: 1,
-      height: 1,
-      notes: '',
-      ruleData: null,
-      permissions: defaultNPCPermissions(),
-      lifecycle: 'ephemeral',
-    }
-    // Optimistic update
-    set((s) => ({
-      entities: { ...s.entities, [entity.id]: entity },
-      sceneEntityMap: {
-        ...s.sceneEntityMap,
-        [sceneId]: [...(s.sceneEntityMap[sceneId] ?? []), { entityId: entity.id, visible: true }],
-      },
-    }))
-    await api.post(`/api/rooms/${roomId}/entities`, entity)
-    await api.post(`/api/rooms/${roomId}/scenes/${sceneId}/entities/${entity.id}`)
-    await api.post(`/api/rooms/${roomId}/tactical/tokens/from-entity`, {
-      entityId: entity.id,
-      x,
-      y,
-    })
-    return entity
-  },
-
   saveEntityAsBlueprint: async (entity) => {
     const roomId = get()._roomId
     if (!roomId) return
@@ -831,12 +799,12 @@ export const useWorldStore = create<WorldState>((set, get) => ({
     await api.patch(`/api/rooms/${roomId}/scenes/${sceneId}/entities/${entityId}`, { visible })
   },
 
-  spawnFromBlueprint: async (sceneId, blueprintId) => {
+  spawnFromBlueprint: async (sceneId, blueprintId, opts = {}) => {
     const roomId = get()._roomId
     if (!roomId) return null
     const result = await api.post<{ entity: Entity }>(
       `/api/rooms/${roomId}/scenes/${sceneId}/spawn`,
-      { blueprintId },
+      { blueprintId, tacticalOnly: opts.tacticalOnly },
     )
     return result.entity
   },


### PR DESCRIPTION
## Summary
- Fix: right-click token creation in tactical mode no longer creates scene_entity_entries
- Fix: blueprint spawn in tactical mode uses `tacticalOnly` flag to skip scene entity linking
- Fix: unlinking ephemeral entities preserves them when they still have tactical tokens (demotion)
- Feature: EntityPanel now shows "战术对象" group for tactical-only tokens with promote/demote actions

## Root Cause
`spawnEphemeralTokenAtPosition` made 3 API calls including `POST /scenes/:sceneId/entities/:entityId` which created a scene_entity_entry for every tactical token. The correct method `createToken` (calling `POST /tactical/tokens/quick`) was already implemented but not wired to the canvas right-click handler.

## Regression Test
`server/__tests__/scenarios/tactical-object-distinction.test.ts` — 5 test cases:
- Quick-create token → no scene_entity_entry
- Blueprint spawn with tacticalOnly=true → no scene_entity_entry
- Blueprint spawn default → has scene_entity_entry (backward compat)
- Unlink ephemeral with tactical token → entity survives (demotion)
- Unlink ephemeral without token → entity deleted (existing behavior)

## Systemic Prevention
- Removed `spawnEphemeralTokenAtPosition` entirely — no code path can accidentally create scene_entity_entries for tactical objects
- Server's `POST /tactical/tokens/quick` is the single source of truth for tactical object creation
- Server unlink now checks `tactical_tokens` table before deleting ephemeral entities

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm test` — 54/54 files, 658/658 tests pass
- [x] Pre-push hook: build + tests pass
- [ ] Manual: right-click canvas in tactical mode → token under "战术对象" not "在场"
- [ ] Manual: promote/demote between groups
- [ ] Manual: blueprint spawn in tactical mode → tactical object