### PR TITLE
chore: add worktree isolation guard to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,33 @@
+# ── Worktree isolation guard ──
+# Compares --git-dir vs --git-common-dir to detect main repo vs worktree:
+# - Main repo: both resolve to the same path → block commit
+# - Worktree: --git-dir points to .git/worktrees/<name> → allow commit
+GIT_DIR_ABS="$(cd "$(git rev-parse --git-dir)" && pwd)" || exit 0
+GIT_COMMON_DIR_ABS="$(cd "$(git rev-parse --git-common-dir)" && pwd)" || exit 0
+
+if [[ "$GIT_DIR_ABS" == "$GIT_COMMON_DIR_ABS" ]]; then
+  BRANCH="$(git branch --show-current)"
+  if [[ -z "$BRANCH" ]]; then
+    echo ""
+    echo "❌ Committing in detached HEAD state in the main working tree is not allowed."
+    echo "   Use a worktree for development work."
+    echo ""
+    exit 1
+  elif [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    echo ""
+    echo "❌ Committing directly on $BRANCH is not allowed."
+    echo "   Create a worktree + feature branch first."
+    echo ""
+    exit 1
+  else
+    echo ""
+    echo "❌ Committing on branch '$BRANCH' outside a worktree."
+    echo "   Use: git worktree add .worktrees/$BRANCH $BRANCH"
+    echo ""
+    exit 1
+  fi
+fi
+
 npx lint-staged
 npx tsc --noEmit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,8 @@ React + Socket.io + SQLite VTT with dual-mode: Scene (atmosphere) + Tactical (co
 
 - **Prettier**: no semicolons, single quotes, trailing commas, printWidth 100
 - **ESLint**: TypeScript strict, react-hooks, `no-restricted-imports` for api module
-- **Husky**: pre-commit runs lint-staged + tsc + doc structure check
+- **Husky**: pre-commit runs worktree isolation guard + lint-staged + tsc + doc structure check
+- **Worktree isolation**: pre-commit hook blocks commits outside worktrees (compares `--git-dir` vs `--git-common-dir`). Agent must always use worktrees for feature work and audit `git diff --cached --stat` before every commit. Agent must NEVER use `--no-verify` to bypass this guard
 - **TypeScript**: strict mode, noUnusedLocals, noUnusedParameters, noUncheckedIndexedAccess
 - **Tests**: Three-tier test pyramid:
   - **Unit tests** (client): `src/**/__tests__/` — vitest + jsdom, store selectors, utils

--- a/docs/conventions/git-workflow.md
+++ b/docs/conventions/git-workflow.md
@@ -7,6 +7,7 @@
 3. **PR 创建和 merge 是两个独立步骤** — merge 需要用户明确指示
 4. **Commit message 使用英文** — 遵循 conventional commits 格式
 5. **不添加 Co-Authored-By 或 AI 声明**
+6. **提交前必须审计 staged 内容** — 运行 `git diff --cached --stat` 确认 staged 文件只包含当前任务的改动。如果分支上有其他人的未提交改动，不要混入
 
 ## 分支命名
 


### PR DESCRIPTION
## Summary
- Add worktree isolation guard to `.husky/pre-commit` — blocks commits in main repo, only allows commits inside git worktrees
- Uses `--git-dir` vs `--git-common-dir` comparison (works for worktrees at any path)
- Handles main branch, feature branches, and detached HEAD
- Escape hatch: `git commit --no-verify` (human emergency only, AI agents prohibited)
- Update git-workflow.md: rule #6 — audit staged content before every commit
- Update CLAUDE.md: document worktree isolation enforcement

## Context
PR #75 accidentally mixed toolbar redesign code with unrelated fix+test work because the Agent committed on a dirty branch outside a worktree. This guard prevents that category of error.

## Test plan
- [x] Commit inside worktree passes guard (verified: this commit)
- [x] 686 unit+integration tests pass
- [ ] After merge: verify main repo commits are blocked
- [ ] After merge: verify `--no-verify` bypasses guard