### PR TITLE
chore: add Claude Code hooks for worktree enforcement

### DIFF
--- a/.claude/hooks/block-main-worktree.sh
+++ b/.claude/hooks/block-main-worktree.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Block edits to files outside .worktrees/ directory.
+# All development must happen in an isolated git worktree.
+
+FILE=$(cat | jq -r '.tool_input.file_path // empty')
+
+if echo "$FILE" | grep -q '/.worktrees/'; then
+  exit 0
+fi
+
+echo '{"decision":"block","reason":"Main worktree edit blocked.","additionalContext":"STOP. Re-read CLAUDE.md. Create a worktree with: git worktree add .worktrees/<name> -b <branch>, then edit files there."}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,13 +5,50 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-main-worktree.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'REMINDER: Re-read CLAUDE.md. 1) NEVER work in main worktree — use git worktree add. 2) Check Required Reading table before coding. 3) Bug fixes MUST include: root cause, regression test, systemic prevention.'"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'REMINDER: Re-read CLAUDE.md. 1) NEVER work in main worktree — use git worktree add. 2) Check Required Reading table before coding. 3) Bug fixes MUST include: root cause, regression test, systemic prevention.'"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Review the conversation above. Did Claude fix a bug in this turn (not just add features, refactor, or answer questions — specifically fix broken behavior)?\n\nIf YES, check whether Claude performed ALL of these steps:\n1. Applied the fix\n2. Added a regression test\n3. Stated the bug category and proposed systemic prevention (a rule, lint check, type constraint, or CLAUDE.md update that prevents the entire category)\n4. Updated CLAUDE.md if the bug revealed a non-obvious pattern\n\nIf a bug was fixed but step 3 (systemic prevention reflection) is missing, return {\"ok\": false, \"reason\": \"Bug fix detected but systemic prevention reflection (step 3 of Bug Fix Workflow) was not performed. State the bug category and propose a structural guard before finishing.\"}.\n\nIf no bug was fixed, or all steps were completed, return {\"ok\": true}.",
+            "prompt": "Review the conversation above. Did Claude fix a bug in this turn (not just add features, refactor, or answer questions — specifically fix broken behavior)?\n\nIf YES, check whether Claude performed ALL of these steps:\n1. Applied the fix\n2. Added a regression test\n3. Stated the bug category and proposed systemic prevention\n4. Updated CLAUDE.md if the bug revealed a non-obvious pattern\n\nIf a bug was fixed but step 3 is missing, return {\"ok\": false, \"reason\": \"Bug fix detected but systemic prevention reflection was not performed.\"}.\n\nIf no bug was fixed, or all steps were completed, return {\"ok\": true}.",
             "model": "claude-haiku-4"
+          },
+          {
+            "type": "command",
+            "command": "echo 'Reminder: Re-read CLAUDE.md before your next task.'"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,10 @@ db/
 dist/
 server/uploads/
 .worktrees/
-.claude/
+# Claude Code — track settings and hooks, ignore everything else
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
 coverage/
 .superpowers/
 data/


### PR DESCRIPTION
## Summary
- Add PreToolUse hook to block Edit/Write in main worktree — forces isolated worktree development
- Add soft reminders on context compaction, subagent start, and stop
- Track `.claude/settings.json` and `.claude/hooks/` in git

🤖 Generated with [Claude Code](https://claude.com/claude-code)