### PR TITLE
docs: asset & entity system unification design (#110)

### DIFF
--- a/docs/design/13-资产与角色系统统一设计.md
+++ b/docs/design/13-资产与角色系统统一设计.md
@@ -1,6 +1,6 @@
 # 资产与角色系统重构设计
 
-> **状态：设计已定，待决问题审查中**
+> **状态：设计已定**
 >
 > 本文档记录了 Asset（资产）、Blueprint（蓝图）、Entity（实体）三系统的重构设计。
 > 对应 Issue：#110 Redesign Blueprint/Entity data model relationship
@@ -295,88 +295,43 @@ MVP 阶段只支持 GM 自行上传。数据模型预留素材库扩展空间但
 - 删除 Blueprint 时已 spawn 的 Entity 不受影响（`ON DELETE SET NULL`）
 - `blueprint_id` 指向已删除的 Blueprint 时 —— Entity 正常存在，仅名称递增功能失效
 
-## 审查待决问题
+## 实施分阶段
 
-以下问题在设计审查中提出，需要在实现前确定方案。
+本设计拆分为多个独立 PR 分阶段实施，每个阶段产出可工作的软件。
 
-### 问题 1：image_url 裸 URL vs asset_id 外键
+### Phase 1：Blueprint 提取 ✅
 
-当前设计中 `blueprints.image_url` 和 `entities.image_url` 都是裸 URL 字符串，没有外键指向 `assets.id`。
+**PR #127** — 将 Blueprint 从 assets 表独立到 blueprints 表。
 
-**影响**：
+- 新增 `blueprints` 表，`entities.blueprint_id` FK 指向 blueprints
+- Blueprint CRUD 路由 + Socket.io 事件
+- worldStore blueprints slice
+- BlueprintDockTab 改读 blueprints store
+- Spawn 路由改查 blueprints 表
+- 移除 assets 表中的 blueprint 相关逻辑
 
-- 删除 asset 时无法级联：GM 删了一张图片，blueprints/entities 中的 `image_url` 变成悬空引用，数据库层面无感知
-- 引用计数难以实现：文档提到"删除时警告"，但没有外键关系，需要全表扫描所有 `image_url` 字段才能判断引用
-- 同一张图片在不同 room database 中 URL 路径不同时，字符串匹配不可靠
+### Phase 2：资产分类清理
 
-**可选方案**：
+**前置：Phase 1 合入 main。**
 
-- A）改用 `image_asset_id TEXT REFERENCES assets(id) ON DELETE SET NULL`，通过 JOIN 拿 URL
-- B）保持裸 URL，接受其局限性，在文档中明确"引用计数通过 URL 字符串匹配实现"
+一个 PR 完成以下三项：
 
-### 问题 2：Maps Tab 筛选会混入 token 图片
+1. **`type` → `media_type` 重命名** — 全栈机械重命名（schema → routes → types → stores → UI）
+2. **上传自动标签** — Maps tab 上传自动加 `map` 标签，Blueprint flow 上传自动加 `token` 标签
+3. **MapDockTab 筛选改进** — 用 `media_type='image' + tag='map'` 替代 `type='image'`，避免 token 图片混入 Maps tab
 
-重构后 Maps tab 使用 `media_type='image'` 筛选，但上传的 token 图片也是 image 类型——会同时出现在 Maps tab 中，导致 token 图淹没地图素材。
+设计决策：
 
-**可选方案**：
+- `handout` 暂保留为 `media_type` 值（语义不完美，但最小化范围）
+- Handout 独立表提取推迟到后续阶段
 
-- A）上传时自动或手动打 tag（如 `map` / `token`），Maps tab 按 tag 筛选
-- B）AssetPicker 在不同调用场景传入不同的 tag 预设
-- C）Maps tab 只展示被当前 room 的场景实际引用过的图片（按使用筛选而非按类型筛选）
+### Phase 3+：待规划
 
-### 问题 3：Spawn 命名计数范围
+以下项目待后续根据优先级规划：
 
-设计中的 spawn 流程使用 `SELECT COUNT(*) FROM entities WHERE blueprint_id = ?` 做全局计数。
-
-**问题**：如果 GM spawn 了 "Goblin 1-5" 后全部删除，再 spawn 会从 "Goblin 1" 重新开始（COUNT 为 0）。如果中间删了 3 号，下一个仍是 "Goblin 6"（COUNT 为 4 → +1=5...不对，COUNT 为 4 → "Goblin 5"，但 "Goblin 5" 已经存在）。
-
-**建议**：改用 `MAX(序号)` 而非 `COUNT`，从已有同 blueprint 的 entity 名称中提取最大编号 +1。当前 `nextNpcName()` 的实现已经在做这件事，spawn 流程应复用而非重写。
-
-### 问题 4：缺少迁移方案具体步骤
-
-文档说"不需要向后兼容"，但现有数据库中已有 `type='blueprint'` 的 asset 和引用它们的 `entity.blueprint_id`。需要一个迁移脚本框架：
-
-```
-1. CREATE TABLE blueprints (...)
-2. 对每个 type='blueprint' 的 asset：
-   a. INSERT INTO blueprints (id, name, image_url, tags, defaults, created_at)
-      VALUES (asset.id, asset.name, asset.url, asset.tags, asset.extra.blueprint, asset.created_at)
-   b. UPDATE assets SET media_type='image', extra='{}' WHERE id = asset.id
-      （或直接 DELETE，取决于该图片是否还需要保留在资产池中）
-3. ALTER TABLE assets: RENAME COLUMN type → media_type
-4. entities.blueprint_id 的值不需要改（如果 blueprint 复用了原 asset 的 id）
-```
-
-### 问题 5：Blueprint CRUD 路由设计未展开
-
-文档提到新增 `server/routes/blueprints.ts`，但只描述了 spawn 流程。以下 API 需要明确：
-
-| 操作               | Endpoint（建议）                                    | Request Body                                     |
-| ------------------ | --------------------------------------------------- | ------------------------------------------------ |
-| 列出所有 Blueprint | `GET /api/rooms/:roomId/blueprints`                 | —                                                |
-| 创建 Blueprint     | `POST /api/rooms/:roomId/blueprints`                | `{ name, imageFile/imageUrl, defaults, tags }`   |
-| 更新 Blueprint     | `PATCH /api/rooms/:roomId/blueprints/:id`            | `{ name?, defaults?, tags?, imageUrl? }`         |
-| 删除 Blueprint     | `DELETE /api/rooms/:roomId/blueprints/:id`           | —                                                |
-| Spawn              | `POST /api/rooms/:roomId/scenes/:sceneId/spawn`     | `{ blueprintId, tacticalOnly? }`                 |
-| Save as Blueprint  | `POST /api/rooms/:roomId/blueprints` (from entity)  | `{ fromEntityId }` 或手动构造 defaults           |
-
-特别需要明确：创建 Blueprint 时是否同时在 assets 表中创建一条 image 记录？还是 AssetPicker 先上传 asset，再用 asset URL 创建 blueprint？
-
-### 问题 6：资产管理次级入口的定位
-
-第 4 个 commit 补充了"次级入口"需求（批量清理、重命名、查看存储），但"具体位置待 UI 实现时确定"过于模糊。
-
-**建议至少确定一个方案**，例如：
-
-- AssetPicker 弹窗底部的"管理全部资产"链接
-- Dock 底部的工具图标（齿轮/文件夹）
-- 设置面板中的子页面
-
-## 其他小问题
-
-- `blueprints` 表缺少 `updated_at` 字段 —— GM 编辑蓝图默认值后无法追踪修改时间，建议补充
-- Entity 表新增 `tags` 字段，但 Characters tab 设计中仅使用文本搜索，未用 TagFilterBar。如果暂不需要 tag 筛选 character，可考虑延迟添加 `tags` 字段，避免过早引入未使用的列
-- Handout 留在 Asset 表的理由（"没有实例化行为"）成立，但按同样的职责分离逻辑，handout 的 title/description 也是游戏语义。建议标注为 future consideration
+- Handout 独立表提取（与 Blueprint 提取类似的模式）
+- AssetPicker 统一图片选择组件
+- 资产管理次级入口（Settings → Asset Management）
 
 ## 关键文件清单
 


### PR DESCRIPTION
## Summary

- Add design discussion document for redesigning the Blueprint/Entity data model relationship
- Records 5 consensus decisions: unified asset pool, tag-based organization, no template sync, preserve existing lifecycle/token model, upload-only for MVP
- Identifies 3 open design points: Blueprint migration to Entity, unified character tab UI, Asset table simplification

## Context

Spun off from #110. This document captures the design discussion on how to reorganize the asset and entity systems. Key direction: Asset system becomes pure file management (no game semantics), Blueprint concept migrates to Entity system, tags replace hard-coded type classification.

## Test plan

- [ ] Review design document for completeness and accuracy
- [ ] Verify all referenced file paths are correct