### PR TITLE
fix: add data/ to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 dist
 db
+data
 .git
 *.md


### PR DESCRIPTION
## Summary
- `.dockerignore` was missing `data/`, causing local `data/global.db` (from dev sessions) to be copied into the Docker image via `COPY . .`
- This led to `SqliteError: table rooms has no column named rule_system_id` because `CREATE TABLE IF NOT EXISTS` skipped schema creation when an old db already existed
- Fix: add `data` to `.dockerignore`

## Root Cause
`.dockerignore` excluded `db` but not `data`. The preview script's `docker build` baked a stale `global.db` into the image.

## Regression Test
N/A — configuration-only change. Verified manually by rebuilding preview after fix.

## Systemic Prevention
The `.dockerignore` now mirrors `.gitignore`'s exclusion of `data/`.