### PR TITLE
fix: use semantic z-ui layer for fixed UI elements

### DIFF
--- a/src/chat/ChatPanel.tsx
+++ b/src/chat/ChatPanel.tsx
@@ -251,7 +251,7 @@ export function ChatPanel({
       {showSpeakerPicker && (
         <div
           ref={speakerPickerRef}
-          className="fixed z-toast bg-glass backdrop-blur-[16px] border border-border-glass rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-y-auto p-1.5 bottom-[62px] right-[440px] w-[200px] max-h-[280px]"
+          className="fixed z-ui bg-glass backdrop-blur-[16px] border border-border-glass rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-y-auto p-1.5 bottom-[62px] right-[440px] w-[200px] max-h-[280px]"
           onPointerDown={(e) => {
             e.stopPropagation()
           }}
@@ -288,7 +288,7 @@ export function ChatPanel({
 
       {/* Chat input + buttons (always visible) */}
       <div
-        className="fixed bottom-3 right-4 z-toast flex gap-1.5 items-stretch"
+        className="fixed bottom-3 right-4 z-ui flex gap-1.5 items-stretch"
         style={{ width: RIGHT_PANEL_WIDTH }}
       >
         <button

--- a/src/combat/TacticalToolbar.tsx
+++ b/src/combat/TacticalToolbar.tsx
@@ -63,7 +63,7 @@ export function TacticalToolbar({ mapRef, role, tacticalInfo }: TacticalToolbarP
 
   return (
     <div
-      className="fixed top-3 z-toast pointer-events-auto"
+      className="fixed top-3 z-ui pointer-events-auto"
       style={{ right: RIGHT_PANEL_WIDTH + 24 }}
       onPointerDown={(e) => {
         e.stopPropagation()

--- a/src/gm/GmDock.tsx
+++ b/src/gm/GmDock.tsx
@@ -158,7 +158,7 @@ export function GmDock({
   if (collapsed) {
     return (
       <div
-        className="fixed bottom-3 left-1/2 -translate-x-1/2 z-toast"
+        className="fixed bottom-3 left-1/2 -translate-x-1/2 z-ui"
         onPointerDown={(e) => {
           e.stopPropagation()
         }}
@@ -186,7 +186,7 @@ export function GmDock({
   return (
     <div
       ref={dockRef}
-      className="fixed bottom-3 left-1/2 -translate-x-1/2 z-toast flex flex-col items-center"
+      className="fixed bottom-3 left-1/2 -translate-x-1/2 z-ui flex flex-col items-center"
       onPointerDown={(e) => {
         e.stopPropagation()
       }}

--- a/src/gm/SceneButton.tsx
+++ b/src/gm/SceneButton.tsx
@@ -29,7 +29,7 @@ export function SceneButton({
   return (
     <>
       <div
-        className="fixed bottom-3 left-4 z-toast font-sans"
+        className="fixed bottom-3 left-4 z-ui font-sans"
         onPointerDown={(e) => {
           e.stopPropagation()
         }}

--- a/src/gm/SceneListPanel.tsx
+++ b/src/gm/SceneListPanel.tsx
@@ -64,7 +64,7 @@ export function SceneListPanel({
   return (
     <div
       ref={panelRef}
-      className="fixed z-toast bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)] flex flex-col"
+      className="fixed z-ui bg-glass backdrop-blur-[12px] rounded-lg border border-border-glass shadow-[0_4px_24px_rgba(0,0,0,0.5)] flex flex-col"
       style={{ bottom: 56, left: 16, width: 280, maxHeight: 420 }}
       onPointerDown={(e) => {
         e.stopPropagation()

--- a/src/layout/HamburgerMenu.tsx
+++ b/src/layout/HamburgerMenu.tsx
@@ -72,7 +72,7 @@ export function HamburgerMenu({ mySeat, onUpdateSeat, onLeaveSeat }: HamburgerMe
 
   return (
     <div
-      className="fixed top-3 left-4 z-toast font-sans"
+      className="fixed top-3 left-4 z-ui font-sans"
       onPointerDown={(e) => {
         e.stopPropagation()
       }}
@@ -98,7 +98,7 @@ export function HamburgerMenu({ mySeat, onUpdateSeat, onLeaveSeat }: HamburgerMe
               setEditing(false)
             }}
           />
-          <div className="absolute top-full left-0 mt-1.5 bg-glass backdrop-blur-[16px] rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.35)] border border-border-glass min-w-[220px] p-1.5 z-toast animate-fade-in">
+          <div className="absolute top-full left-0 mt-1.5 bg-glass backdrop-blur-[16px] rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.35)] border border-border-glass min-w-[220px] p-1.5 z-ui animate-fade-in">
             {/* Seat profile section */}
             <div className="px-3 py-2.5">
               <div className="flex items-center gap-2.5">

--- a/src/layout/MyCharacterCard.tsx
+++ b/src/layout/MyCharacterCard.tsx
@@ -15,7 +15,7 @@ export function MyCharacterCard({ entity, onUpdateEntity }: MyCharacterCardProps
 
   return (
     <div
-      className="fixed top-1/2 left-0 -translate-y-1/2 z-toast flex pointer-events-none"
+      className="fixed top-1/2 left-0 -translate-y-1/2 z-ui flex pointer-events-none"
       onPointerDown={(e) => {
         e.stopPropagation()
       }}

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -243,7 +243,7 @@ export function PortraitBar({
   // Collapsed state: show small expand button
   if (!portraitBarVisible) {
     return (
-      <div className="fixed top-3 left-1/2 -translate-x-1/2 z-toast pointer-events-none flex flex-col items-center">
+      <div className="fixed top-3 left-1/2 -translate-x-1/2 z-ui pointer-events-none flex flex-col items-center">
         <button
           onClick={() => {
             setPortraitBarVisible(true)
@@ -259,7 +259,7 @@ export function PortraitBar({
 
   if (visibleEntities.length === 0) {
     return (
-      <div className="fixed top-3 left-1/2 -translate-x-1/2 z-toast pointer-events-none flex flex-col items-center">
+      <div className="fixed top-3 left-1/2 -translate-x-1/2 z-ui pointer-events-none flex flex-col items-center">
         <div className="flex items-center gap-1.5 bg-glass backdrop-blur-[16px] rounded-[28px] px-4 py-2 shadow-[0_4px_20px_rgba(0,0,0,0.25)] border border-border-glass pointer-events-auto">
           <Users size={14} strokeWidth={1.5} className="text-text-muted/40" />
           <span className="text-text-muted/40 text-[11px]">{t('portrait.no_characters')}</span>
@@ -535,7 +535,7 @@ export function PortraitBar({
   return (
     <div
       ref={portraitBarRef}
-      className="fixed top-3 left-1/2 -translate-x-1/2 z-toast pointer-events-none flex flex-col items-center gap-[3px]"
+      className="fixed top-3 left-1/2 -translate-x-1/2 z-ui pointer-events-none flex flex-col items-center gap-[3px]"
       onPointerDown={(e) => {
         e.stopPropagation()
       }}

--- a/src/scene/AmbientAudio.tsx
+++ b/src/scene/AmbientAudio.tsx
@@ -112,7 +112,7 @@ export function AmbientAudio({ audioUrl, volume }: AmbientAudioProps) {
 
   return (
     <div
-      className="fixed bottom-3 right-4 z-toast flex items-center gap-1.5 font-sans"
+      className="fixed bottom-3 right-4 z-ui flex items-center gap-1.5 font-sans"
       onPointerDown={(e) => {
         e.stopPropagation()
       }}


### PR DESCRIPTION
## Summary
- Replace `z-toast` (10000) with `z-ui` (1000) on all fixed UI elements across 9 files
- Atomic change: all files modified simultaneously to prevent z-layer conflicts
- Prerequisite for Radix UI overlay migration (PR series)

## Context
Almost all fixed UI elements were using `z-toast` (10000), which is meant only for toast notifications. This made it impossible to add overlay menus at `z-popover` (5000) — they'd be hidden behind the UI. See design doc: `docs/design/13-Radix-Popover迁移设计.md` section 6.

## Files changed (9)
| File | Occurrences |
|------|-------------|
| `PortraitBar.tsx` | 3 |
| `HamburgerMenu.tsx` | 2 |
| `GmDock.tsx` | 2 |
| `ChatPanel.tsx` | 2 |
| `MyCharacterCard.tsx` | 1 |
| `SceneButton.tsx` | 1 |
| `SceneListPanel.tsx` | 1 |
| `AmbientAudio.tsx` | 1 |
| `TacticalToolbar.tsx` | 1 |

Files that correctly retain `z-toast`: `ToastProvider.tsx`, `ConfirmPopover.tsx`, `ContextMenu.tsx` (latter two to be deleted in follow-up PR).

## Test plan
- [x] `tsc -b` — no TypeScript errors
- [x] `eslint` — clean
- [x] `vitest run` — 770 tests pass
- [x] `vite build` — production build succeeds
- [ ] e2e tests pass
- [ ] Docker preview manual verification