### PR TITLE
feat: migrate DOM context menus to Radix ContextMenu

### DIFF
--- a/src/dock/BlueprintDockTab.tsx
+++ b/src/dock/BlueprintDockTab.tsx
@@ -1,9 +1,11 @@
 import { useRef, useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { X, Plus, CircleDot } from 'lucide-react'
+import * as ContextMenu from '@radix-ui/react-context-menu'
 import type { Blueprint } from '../shared/entityTypes'
 import { useWorldStore } from '../stores/worldStore'
-import { ContextMenu, type ContextMenuItem } from '../shared/ContextMenu'
+import { ContextMenuContent } from '../ui/primitives/ContextMenuContent'
+import { ContextMenuItem } from '../ui/primitives/ContextMenuItem'
 import { useToast } from '../ui/useToast'
 import { TagFilterBar } from '../ui/TagFilterBar'
 
@@ -39,9 +41,6 @@ export function BlueprintDockTab({ onSpawnToken, onAddToActive, isTactical }: To
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState('')
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; bpId: string } | null>(
-    null,
-  )
   const [selectedTags, setSelectedTags] = useState<string[]>([])
 
   // Read from world store — derive blueprints from assets with type === 'blueprint'
@@ -116,12 +115,6 @@ export function BlueprintDockTab({ onSpawnToken, onAddToActive, isTactical }: To
     setEditingId(null)
   }
 
-  const handleContextMenu = (e: React.MouseEvent, bpId: string) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setContextMenu({ x: e.clientX, y: e.clientY, bpId })
-  }
-
   const [editingTagsId, setEditingTagsId] = useState<string | null>(null)
   const [tagInput, setTagInput] = useState('')
 
@@ -145,42 +138,6 @@ export function BlueprintDockTab({ onSpawnToken, onAddToActive, isTactical }: To
       string,
       unknown
     >)
-  }
-
-  const getContextMenuItems = (bp: Blueprint): ContextMenuItem[] => {
-    const items: ContextMenuItem[] = []
-    if (isTactical) {
-      items.push({
-        label: t('blueprint.spawn_on_map'),
-        testId: 'ctx-spawn-on-map',
-        onClick: () => {
-          onSpawnToken(bp)
-        },
-      })
-    }
-    items.push({
-      label: t('blueprint.add_as_npc'),
-      testId: 'ctx-add-as-npc',
-      onClick: () => {
-        onAddToActive(bp)
-      },
-    })
-    items.push({
-      label: t('blueprint.edit_tags'),
-      onClick: () => {
-        setEditingTagsId(bp.id)
-        setTagInput('')
-      },
-    })
-    items.push({
-      label: t('blueprint.delete_blueprint'),
-      testId: 'ctx-delete-blueprint',
-      onClick: () => {
-        handleDelete(bp)
-      },
-      color: '#f87171',
-    })
-    return items
   }
 
   return (
@@ -228,82 +185,120 @@ export function BlueprintDockTab({ onSpawnToken, onAddToActive, isTactical }: To
         {blueprints.map((bp) => {
           const isHovered = hoveredId === bp.id
           return (
-            <div
-              key={bp.id}
-              className="flex flex-col items-center gap-1 relative"
-              onMouseEnter={() => {
-                setHoveredId(bp.id)
-              }}
-              onMouseLeave={() => {
-                setHoveredId(null)
-              }}
-              onContextMenu={(e) => {
-                handleContextMenu(e, bp.id)
-              }}
-            >
-              {/* Circular token image */}
-              <div
-                onClick={() => {
-                  if (isTactical) {
-                    onSpawnToken(bp)
-                  } else {
-                    onAddToActive(bp)
-                  }
-                }}
-                className="w-14 h-14 rounded-full overflow-hidden cursor-pointer shrink-0 transition-shadow duration-fast"
-                style={{
-                  border: `3px solid ${bp.defaultColor}`,
-                  boxShadow: isHovered ? `0 0 12px ${bp.defaultColor}44` : 'none',
-                }}
-              >
-                <img
-                  src={bp.imageUrl}
-                  alt={bp.name}
-                  className="w-full h-full object-cover block"
-                  draggable={false}
-                />
-              </div>
-
-              {/* Name label (double-click to edit) */}
-              {editingId === bp.id ? (
-                <input
-                  value={editName}
-                  onChange={(e) => {
-                    setEditName(e.target.value)
+            <ContextMenu.Root key={bp.id}>
+              <ContextMenu.Trigger asChild>
+                <div
+                  className="flex flex-col items-center gap-1 relative"
+                  onMouseEnter={() => {
+                    setHoveredId(bp.id)
                   }}
-                  onBlur={commitEdit}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commitEdit()
-                    if (e.key === 'Escape') setEditingId(null)
+                  onMouseLeave={() => {
+                    setHoveredId(null)
                   }}
-                  autoFocus
-                  className="w-16 text-[9px] text-center bg-surface border border-border-glass rounded text-text-primary outline-none px-1 py-0.5"
-                />
-              ) : (
-                <span
-                  onDoubleClick={() => {
-                    startEdit(bp)
-                  }}
-                  className="text-[9px] text-text-muted/60 text-center overflow-hidden text-ellipsis whitespace-nowrap max-w-[72px] cursor-default"
                 >
-                  {bp.name}
-                </span>
-              )}
+                  {/* Circular token image */}
+                  <div
+                    onClick={() => {
+                      if (isTactical) {
+                        onSpawnToken(bp)
+                      } else {
+                        onAddToActive(bp)
+                      }
+                    }}
+                    className="w-14 h-14 rounded-full overflow-hidden cursor-pointer shrink-0 transition-shadow duration-fast"
+                    style={{
+                      border: `3px solid ${bp.defaultColor}`,
+                      boxShadow: isHovered ? `0 0 12px ${bp.defaultColor}44` : 'none',
+                    }}
+                  >
+                    <img
+                      src={bp.imageUrl}
+                      alt={bp.name}
+                      className="w-full h-full object-cover block"
+                      draggable={false}
+                    />
+                  </div>
 
-              {/* Delete button on hover */}
-              {isHovered && (
-                <button
-                  aria-label={t('blueprint.delete_blueprint')}
-                  onClick={(e) => {
-                    e.stopPropagation()
+                  {/* Name label (double-click to edit) */}
+                  {editingId === bp.id ? (
+                    <input
+                      value={editName}
+                      onChange={(e) => {
+                        setEditName(e.target.value)
+                      }}
+                      onBlur={commitEdit}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') commitEdit()
+                        if (e.key === 'Escape') setEditingId(null)
+                      }}
+                      autoFocus
+                      className="w-16 text-[9px] text-center bg-surface border border-border-glass rounded text-text-primary outline-none px-1 py-0.5"
+                    />
+                  ) : (
+                    <span
+                      onDoubleClick={() => {
+                        startEdit(bp)
+                      }}
+                      className="text-[9px] text-text-muted/60 text-center overflow-hidden text-ellipsis whitespace-nowrap max-w-[72px] cursor-default"
+                    >
+                      {bp.name}
+                    </span>
+                  )}
+
+                  {/* Delete button on hover */}
+                  {isHovered && (
+                    <button
+                      aria-label={t('blueprint.delete_blueprint')}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        handleDelete(bp)
+                      }}
+                      className="absolute -top-0.5 right-0.5 w-4 h-4 rounded-full bg-black/70 border-none cursor-pointer text-danger flex items-center justify-center p-0"
+                    >
+                      <X size={10} strokeWidth={2.5} />
+                    </button>
+                  )}
+                </div>
+              </ContextMenu.Trigger>
+
+              <ContextMenuContent>
+                {isTactical && (
+                  <ContextMenuItem
+                    data-testid="ctx-spawn-on-map"
+                    onSelect={() => {
+                      onSpawnToken(bp)
+                    }}
+                  >
+                    {t('blueprint.spawn_on_map')}
+                  </ContextMenuItem>
+                )}
+                <ContextMenuItem
+                  data-testid="ctx-add-as-npc"
+                  onSelect={() => {
+                    onAddToActive(bp)
+                  }}
+                >
+                  {t('blueprint.add_as_npc')}
+                </ContextMenuItem>
+                <ContextMenuItem
+                  onSelect={() => {
+                    setEditingTagsId(bp.id)
+                    setTagInput('')
+                  }}
+                >
+                  {t('blueprint.edit_tags')}
+                </ContextMenuItem>
+                <ContextMenuItem
+                  data-testid="ctx-delete-blueprint"
+                  variant="danger"
+                  onSelect={() => {
                     handleDelete(bp)
                   }}
-                  className="absolute -top-0.5 right-0.5 w-4 h-4 rounded-full bg-black/70 border-none cursor-pointer text-danger flex items-center justify-center p-0"
                 >
-                  <X size={10} strokeWidth={2.5} />
-                </button>
-              )}
-            </div>
+                  {t('blueprint.delete_blueprint')}
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu.Root>
           )
         })}
 
@@ -318,23 +313,6 @@ export function BlueprintDockTab({ onSpawnToken, onAddToActive, isTactical }: To
           <span className="text-[9px] text-text-muted/30">{t('blueprint.add_token')}</span>
         </div>
       </div>
-
-      {/* Context menu */}
-      {contextMenu &&
-        (() => {
-          const bp = blueprints.find((b) => b.id === contextMenu.bpId)
-          if (!bp) return null
-          return (
-            <ContextMenu
-              x={contextMenu.x}
-              y={contextMenu.y}
-              items={getContextMenuItems(bp)}
-              onClose={() => {
-                setContextMenu(null)
-              }}
-            />
-          )
-        })()}
 
       {/* Tag editor inline panel */}
       {editingTagsId &&

--- a/src/dock/MapDockTab.tsx
+++ b/src/dock/MapDockTab.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plus, FolderOpen, Loader2 } from 'lucide-react'
+import * as ContextMenu from '@radix-ui/react-context-menu'
 import { useWorldStore } from '../stores/worldStore'
 import type { AssetMeta } from '../shared/assetTypes'
 import { isVideoUrl } from '../shared/assetUpload'
-import { ContextMenu, type ContextMenuItem } from '../shared/ContextMenu'
+import { ContextMenuContent } from '../ui/primitives/ContextMenuContent'
+import { ContextMenuItem } from '../ui/primitives/ContextMenuItem'
 import { useToast } from '../ui/useToast'
 
 interface MapDockTabProps {
@@ -13,12 +15,6 @@ interface MapDockTabProps {
   onSetAsBackground?: (sceneId: string, imageUrl: string) => void
   onSetAsTacticalMap?: (imageUrl: string) => void
   onShowcaseImage?: (imageUrl: string) => void
-}
-
-interface ContextState {
-  x: number
-  y: number
-  asset: AssetMeta
 }
 
 export function MapDockTab({
@@ -32,7 +28,6 @@ export function MapDockTab({
   const fileRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
   const [hoveredId, setHoveredId] = useState<string | null>(null)
-  const [contextMenu, setContextMenu] = useState<ContextState | null>(null)
 
   const allAssets = useWorldStore((s) => s.assets)
   const upload = useWorldStore((s) => s.uploadAsset)
@@ -67,52 +62,6 @@ export function MapDockTab({
     })
   }
 
-  const handleContextMenu = (e: React.MouseEvent, asset: AssetMeta) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setContextMenu({ x: e.clientX, y: e.clientY, asset })
-  }
-
-  const buildContextMenuItems = (asset: AssetMeta): ContextMenuItem[] => {
-    const items: ContextMenuItem[] = []
-
-    if (onSetAsBackground && activeSceneId && asset.url) {
-      items.push({
-        label: t('map.set_scene_bg'),
-        testId: 'ctx-set-bg',
-        onClick: () => {
-          onSetAsBackground(activeSceneId, asset.url)
-        },
-      })
-    }
-    if (onSetAsTacticalMap && asset.url) {
-      items.push({
-        label: t('map.set_tactical_map'),
-        onClick: () => {
-          onSetAsTacticalMap(asset.url)
-        },
-      })
-    }
-    if (onShowcaseImage && asset.url) {
-      items.push({
-        label: t('map.showcase'),
-        onClick: () => {
-          onShowcaseImage(asset.url)
-        },
-      })
-    }
-    items.push({
-      label: 'Delete',
-      testId: 'ctx-delete',
-      onClick: () => {
-        handleDelete(asset)
-      },
-      color: 'var(--color-danger)',
-    })
-
-    return items
-  }
-
   return (
     <div>
       <input
@@ -143,68 +92,108 @@ export function MapDockTab({
         {assets.map((asset) => {
           const isHovered = hoveredId === asset.id
           return (
-            <div
-              key={asset.id}
-              role="button"
-              tabIndex={0}
-              className="relative cursor-pointer rounded-lg overflow-hidden border-2 transition-all duration-fast border-border-glass"
-              onClick={() => {
-                if (!activeSceneId || !asset.url) return
-                if (isTactical) {
-                  onSetAsTacticalMap?.(asset.url)
-                } else {
-                  onSetAsBackground?.(activeSceneId, asset.url)
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  if (!activeSceneId || !asset.url) return
-                  if (isTactical) {
-                    onSetAsTacticalMap?.(asset.url)
-                  } else {
-                    onSetAsBackground?.(activeSceneId, asset.url)
-                  }
-                }
-              }}
-              onContextMenu={(e) => {
-                handleContextMenu(e, asset)
-              }}
-              onMouseEnter={() => {
-                setHoveredId(asset.id)
-              }}
-              onMouseLeave={() => {
-                setHoveredId(null)
-              }}
-            >
-              {isVideoUrl(asset.url) ? (
-                <video
-                  src={asset.url}
-                  muted
-                  loop
-                  autoPlay
-                  playsInline
-                  className="w-full h-[70px] object-cover block"
-                  draggable={false}
-                />
-              ) : (
-                <img
-                  src={asset.url}
-                  alt={asset.name}
-                  className="w-full h-[70px] object-cover block"
-                  draggable={false}
-                />
-              )}
-              <div className="px-1.5 py-1 text-[10px] overflow-hidden text-ellipsis whitespace-nowrap bg-black/30 text-text-muted/60">
-                {asset.name || t('map.untitled')}
-              </div>
+            <ContextMenu.Root key={asset.id}>
+              <ContextMenu.Trigger asChild>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className="relative cursor-pointer rounded-lg overflow-hidden border-2 transition-all duration-fast border-border-glass"
+                  onClick={() => {
+                    if (!activeSceneId || !asset.url) return
+                    if (isTactical) {
+                      onSetAsTacticalMap?.(asset.url)
+                    } else {
+                      onSetAsBackground?.(activeSceneId, asset.url)
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      if (!activeSceneId || !asset.url) return
+                      if (isTactical) {
+                        onSetAsTacticalMap?.(asset.url)
+                      } else {
+                        onSetAsBackground?.(activeSceneId, asset.url)
+                      }
+                    }
+                  }}
+                  onMouseEnter={() => {
+                    setHoveredId(asset.id)
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredId(null)
+                  }}
+                >
+                  {isVideoUrl(asset.url) ? (
+                    <video
+                      src={asset.url}
+                      muted
+                      loop
+                      autoPlay
+                      playsInline
+                      className="w-full h-[70px] object-cover block"
+                      draggable={false}
+                    />
+                  ) : (
+                    <img
+                      src={asset.url}
+                      alt={asset.name}
+                      className="w-full h-[70px] object-cover block"
+                      draggable={false}
+                    />
+                  )}
+                  <div className="px-1.5 py-1 text-[10px] overflow-hidden text-ellipsis whitespace-nowrap bg-black/30 text-text-muted/60">
+                    {asset.name || t('map.untitled')}
+                  </div>
 
-              {/* Hover indicator for right-click */}
-              {isHovered && (
-                <div className="absolute top-1 right-1 w-[18px] h-[18px] rounded-full bg-black/40 flex items-center justify-center text-white/50 text-[8px]">
-                  ···
+                  {/* Hover indicator for right-click */}
+                  {isHovered && (
+                    <div className="absolute top-1 right-1 w-[18px] h-[18px] rounded-full bg-black/40 flex items-center justify-center text-white/50 text-[8px]">
+                      ···
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
+              </ContextMenu.Trigger>
+
+              <ContextMenuContent>
+                {onSetAsBackground && activeSceneId && asset.url && (
+                  <ContextMenuItem
+                    data-testid="ctx-set-bg"
+                    onSelect={() => {
+                      onSetAsBackground(activeSceneId, asset.url)
+                    }}
+                  >
+                    {t('map.set_scene_bg')}
+                  </ContextMenuItem>
+                )}
+                {onSetAsTacticalMap && asset.url && (
+                  <ContextMenuItem
+                    onSelect={() => {
+                      onSetAsTacticalMap(asset.url)
+                    }}
+                  >
+                    {t('map.set_tactical_map')}
+                  </ContextMenuItem>
+                )}
+                {onShowcaseImage && asset.url && (
+                  <ContextMenuItem
+                    onSelect={() => {
+                      onShowcaseImage(asset.url)
+                    }}
+                  >
+                    {t('map.showcase')}
+                  </ContextMenuItem>
+                )}
+                <ContextMenuItem
+                  data-testid="ctx-delete"
+                  variant="danger"
+                  onSelect={() => {
+                    handleDelete(asset)
+                  }}
+                >
+                  Delete
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu.Root>
           )
         })}
 
@@ -229,18 +218,6 @@ export function MapDockTab({
           )}
         </button>
       </div>
-
-      {/* Right-click context menu */}
-      {contextMenu && (
-        <ContextMenu
-          x={contextMenu.x}
-          y={contextMenu.y}
-          items={buildContextMenuItems(contextMenu.asset)}
-          onClose={() => {
-            setContextMenu(null)
-          }}
-        />
-      )}
     </div>
   )
 }

--- a/src/layout/PortraitBar.tsx
+++ b/src/layout/PortraitBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { Users, ChevronUp, Plus } from 'lucide-react'
+import * as ContextMenu from '@radix-ui/react-context-menu'
 import { useUiStore } from '../stores/uiStore'
 import type { Entity, SceneEntityEntry } from '../shared/entityTypes'
 import type { TacticalInfo } from '../stores/worldStore'
@@ -9,7 +10,8 @@ import { useWorldStore } from '../stores/worldStore'
 import { canSee, canEdit, defaultPCPermissions } from '../shared/permissions'
 import { statusColor } from '../shared/tokenUtils'
 import { generateTokenId } from '../shared/idUtils'
-import { ContextMenu, type ContextMenuItem } from '../shared/ContextMenu'
+import { ContextMenuContent } from '../ui/primitives/ContextMenuContent'
+import { ContextMenuItem } from '../ui/primitives/ContextMenuItem'
 import { CharacterHoverPreview } from './CharacterHoverPreview'
 import { useRulePlugin } from '../rules/useRulePlugin'
 
@@ -115,9 +117,6 @@ export function PortraitBar({
   const plugin = useRulePlugin()
   const Card = plugin.characterUI.EntityCard
 
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; entityId: string } | null>(
-    null,
-  )
   const [activeTab, setActiveTab] = useState<PortraitTabId>('characters')
 
   // Auto-switch to initiative tab when combat starts
@@ -277,81 +276,6 @@ export function PortraitBar({
   )
   const hasSection = partyEntities.length > 0 && sceneEntities.length > 0
 
-  const handleContextMenu = (e: React.MouseEvent, entityId: string) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setContextMenu({ x: e.clientX, y: e.clientY, entityId })
-  }
-
-  const getContextMenuItems = (entity: Entity): ContextMenuItem[] => {
-    const items: ContextMenuItem[] = []
-
-    if (mySeatId && canEdit(entity.permissions, mySeatId, role)) {
-      items.push({
-        label: t('portrait.set_active'),
-        onClick: () => {
-          onSetActiveCharacter(entity.id)
-        },
-        disabled: activeCharacterId === entity.id,
-      })
-    }
-
-    items.push({
-      label: t('portrait.inspect'),
-      onClick: () => {
-        const el = portraitBarRef.current?.querySelector(
-          `[data-char-id="${entity.id}"]`,
-        ) as HTMLElement | null
-        if (el) setLockedRect(el.getBoundingClientRect())
-        onInspectCharacter(entity.id)
-      },
-    })
-
-    if (isGM) {
-      // Backstage toggle — only for entities currently visible and in scene
-      const isVisible = visibilityMap.get(entity.id) ?? true
-      if (isVisible && activeSceneId && sceneIdSet.has(entity.id)) {
-        items.push({
-          label: t('portrait.off_stage'),
-          onClick: () => {
-            if (activeSceneId) void toggleEntityVisibility(activeSceneId, entity.id, false)
-          },
-        })
-      }
-
-      // Save as blueprint
-      items.push({
-        label: t('portrait.save_as_blueprint'),
-        onClick: () => {
-          void saveEntityAsBlueprint(entity)
-        },
-      })
-
-      // Save as reusable character (only for ephemeral entities)
-      if (entity.lifecycle === 'ephemeral') {
-        items.push({
-          label: t('portrait.save_as_character'),
-          onClick: () => {
-            void updateEntity(entity.id, { lifecycle: 'reusable' })
-          },
-        })
-      }
-
-      // Remove from scene
-      if (entity.lifecycle !== 'persistent') {
-        items.push({
-          label: t('portrait.remove'),
-          onClick: () => {
-            onRemoveFromScene(entity.id)
-          },
-          color: '#f87171',
-        })
-      }
-    }
-
-    return items
-  }
-
   const renderPortrait = (entity: Entity) => {
     const isOwner = mySeatId ? canEdit(entity.permissions, mySeatId, role) : false
     const isInspected = inspectedCharacterId === entity.id
@@ -369,129 +293,199 @@ export function PortraitBar({
     const isPC = !!ownerSeatId
 
     return (
-      <div
-        key={entity.id}
-        data-char-id={entity.id}
-        draggable={isGM}
-        onDragStart={(e) => {
-          e.dataTransfer.setData('application/x-entity-id', entity.id)
-          e.dataTransfer.effectAllowed = 'copy'
-        }}
-        className="relative cursor-pointer transition-transform duration-fast"
-        onClick={(e) => {
-          handlePortraitClick(entity.id, e.currentTarget as HTMLElement)
-        }}
-        onContextMenu={(e) => {
-          handleContextMenu(e, entity.id)
-        }}
-        onMouseEnter={(e) => {
-          if (!isOwner) (e.currentTarget as HTMLElement).style.transform = 'scale(1.08)'
-          handlePortraitMouseEnter(entity.id, e.currentTarget as HTMLElement)
-        }}
-        onMouseLeave={(e) => {
-          if (!isOwner) (e.currentTarget as HTMLElement).style.transform = 'scale(1)'
-          handlePortraitMouseLeave()
-        }}
-        title={`${entity.name}${statuses.length > 0 ? '\n' + statuses.map((s) => s.label).join(', ') : ''}`}
-      >
-        {/* SVG ring progress */}
-        <svg
-          width={PORTRAIT_SIZE}
-          height={PORTRAIT_SIZE}
-          className="absolute top-0 left-0 pointer-events-none"
-        >
-          {displayResources.map((_, i) => (
-            <ResourceRingBg key={`bg-${i}`} index={i} size={PORTRAIT_SIZE} />
-          ))}
-          {displayResources.map((res, i) => {
-            const pct = res.max > 0 ? res.current / res.max : 0
-            return (
-              <ResourceRing key={i} index={i} pct={pct} color={res.color} size={PORTRAIT_SIZE} />
-            )
-          })}
-        </svg>
+      <ContextMenu.Root key={entity.id}>
+        <ContextMenu.Trigger asChild>
+          <div
+            data-char-id={entity.id}
+            draggable={isGM}
+            onDragStart={(e) => {
+              e.dataTransfer.setData('application/x-entity-id', entity.id)
+              e.dataTransfer.effectAllowed = 'copy'
+            }}
+            className="relative cursor-pointer transition-transform duration-fast"
+            onClick={(e) => {
+              handlePortraitClick(entity.id, e.currentTarget as HTMLElement)
+            }}
+            onMouseEnter={(e) => {
+              if (!isOwner) (e.currentTarget as HTMLElement).style.transform = 'scale(1.08)'
+              handlePortraitMouseEnter(entity.id, e.currentTarget as HTMLElement)
+            }}
+            onMouseLeave={(e) => {
+              if (!isOwner) (e.currentTarget as HTMLElement).style.transform = 'scale(1)'
+              handlePortraitMouseLeave()
+            }}
+            title={`${entity.name}${statuses.length > 0 ? '\n' + statuses.map((s) => s.label).join(', ') : ''}`}
+          >
+            {/* SVG ring progress */}
+            <svg
+              width={PORTRAIT_SIZE}
+              height={PORTRAIT_SIZE}
+              className="absolute top-0 left-0 pointer-events-none"
+            >
+              {displayResources.map((_, i) => (
+                <ResourceRingBg key={`bg-${i}`} index={i} size={PORTRAIT_SIZE} />
+              ))}
+              {displayResources.map((res, i) => {
+                const pct = res.max > 0 ? res.current / res.max : 0
+                return (
+                  <ResourceRing
+                    key={i}
+                    index={i}
+                    pct={pct}
+                    color={res.color}
+                    size={PORTRAIT_SIZE}
+                  />
+                )
+              })}
+            </svg>
 
-        {/* Portrait image */}
-        <div
-          style={{
-            width: PORTRAIT_SIZE,
-            height: PORTRAIT_SIZE,
-          }}
-          className="flex items-center justify-center"
-        >
-          {entity.imageUrl ? (
-            <img
-              src={entity.imageUrl}
-              alt={entity.name}
-              style={{
-                width: IMG_SIZE,
-                height: IMG_SIZE,
-                border: isInspected
-                  ? '2px solid #fff'
-                  : isActive
-                    ? `2px solid ${entity.color}`
-                    : '2px solid rgba(255,255,255,0.15)',
-                boxShadow: isInspected ? `0 0 12px ${entity.color}88` : 'none',
-              }}
-              className="rounded-full object-cover block transition-[border-color,box-shadow] duration-200"
-            />
-          ) : (
+            {/* Portrait image */}
             <div
               style={{
-                width: IMG_SIZE,
-                height: IMG_SIZE,
-                background: `linear-gradient(135deg, ${entity.color}, ${entity.color}aa)`,
-                border: isInspected ? '2px solid #fff' : '2px solid rgba(255,255,255,0.15)',
-                boxShadow: isInspected ? `0 0 12px ${entity.color}88` : 'none',
+                width: PORTRAIT_SIZE,
+                height: PORTRAIT_SIZE,
               }}
-              className="rounded-full flex items-center justify-center text-white text-sm font-bold font-sans box-border transition-[border-color,box-shadow] duration-200"
+              className="flex items-center justify-center"
             >
-              {entity.name.charAt(0).toUpperCase()}
-            </div>
-          )}
-        </div>
-
-        {/* Online indicator (PC only) */}
-        {isPC && isOnline && (
-          <div className="absolute bottom-px right-px w-2.5 h-2.5 rounded-full bg-success border-2 border-glass shadow-[0_0_6px_rgba(34,197,94,0.5)]" />
-        )}
-
-        {/* Status dots (top-right) */}
-        {statuses.length > 0 && (
-          <div className="absolute -top-px -right-0.5 flex gap-0.5">
-            {statuses.slice(0, maxStatusDots).map((s, i) => {
-              const sc = statusColor(s.label)
-              return (
-                <div
-                  key={i}
-                  className="w-[7px] h-[7px] rounded-full"
+              {entity.imageUrl ? (
+                <img
+                  src={entity.imageUrl}
+                  alt={entity.name}
                   style={{
-                    background: sc,
-                    border: '1px solid rgba(15, 15, 25, 0.85)',
-                    boxShadow: `0 0 4px ${sc}66`,
+                    width: IMG_SIZE,
+                    height: IMG_SIZE,
+                    border: isInspected
+                      ? '2px solid #fff'
+                      : isActive
+                        ? `2px solid ${entity.color}`
+                        : '2px solid rgba(255,255,255,0.15)',
+                    boxShadow: isInspected ? `0 0 12px ${entity.color}88` : 'none',
                   }}
+                  className="rounded-full object-cover block transition-[border-color,box-shadow] duration-200"
                 />
-              )
-            })}
-            {statuses.length > maxStatusDots && (
-              <div className="text-[7px] font-bold text-text-muted/60 font-sans leading-[7px]">
-                +{statuses.length - maxStatusDots}
+              ) : (
+                <div
+                  style={{
+                    width: IMG_SIZE,
+                    height: IMG_SIZE,
+                    background: `linear-gradient(135deg, ${entity.color}, ${entity.color}aa)`,
+                    border: isInspected ? '2px solid #fff' : '2px solid rgba(255,255,255,0.15)',
+                    boxShadow: isInspected ? `0 0 12px ${entity.color}88` : 'none',
+                  }}
+                  className="rounded-full flex items-center justify-center text-white text-sm font-bold font-sans box-border transition-[border-color,box-shadow] duration-200"
+                >
+                  {entity.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+
+            {/* Online indicator (PC only) */}
+            {isPC && isOnline && (
+              <div className="absolute bottom-px right-px w-2.5 h-2.5 rounded-full bg-success border-2 border-glass shadow-[0_0_6px_rgba(34,197,94,0.5)]" />
+            )}
+
+            {/* Status dots (top-right) */}
+            {statuses.length > 0 && (
+              <div className="absolute -top-px -right-0.5 flex gap-0.5">
+                {statuses.slice(0, maxStatusDots).map((s, i) => {
+                  const sc = statusColor(s.label)
+                  return (
+                    <div
+                      key={i}
+                      className="w-[7px] h-[7px] rounded-full"
+                      style={{
+                        background: sc,
+                        border: '1px solid rgba(15, 15, 25, 0.85)',
+                        boxShadow: `0 0 4px ${sc}66`,
+                      }}
+                    />
+                  )
+                })}
+                {statuses.length > maxStatusDots && (
+                  <div className="text-[7px] font-bold text-text-muted/60 font-sans leading-[7px]">
+                    +{statuses.length - maxStatusDots}
+                  </div>
+                )}
               </div>
             )}
-          </div>
-        )}
 
-        {/* NPC indicator (small diamond) */}
-        {!isPC && (
-          <div
-            className="absolute bottom-px left-px w-2 h-2 bg-warning rounded-[1px]"
-            style={{
-              transform: 'rotate(45deg)',
-              border: '1px solid rgba(15, 15, 25, 0.85)',
+            {/* NPC indicator (small diamond) */}
+            {!isPC && (
+              <div
+                className="absolute bottom-px left-px w-2 h-2 bg-warning rounded-[1px]"
+                style={{
+                  transform: 'rotate(45deg)',
+                  border: '1px solid rgba(15, 15, 25, 0.85)',
+                }}
+              />
+            )}
+          </div>
+        </ContextMenu.Trigger>
+
+        <ContextMenuContent>
+          {mySeatId && canEdit(entity.permissions, mySeatId, role) && (
+            <ContextMenuItem
+              disabled={activeCharacterId === entity.id}
+              onSelect={() => {
+                onSetActiveCharacter(entity.id)
+              }}
+            >
+              {t('portrait.set_active')}
+            </ContextMenuItem>
+          )}
+          <ContextMenuItem
+            onSelect={() => {
+              const el = portraitBarRef.current?.querySelector(
+                `[data-char-id="${entity.id}"]`,
+              ) as HTMLElement | null
+              if (el) setLockedRect(el.getBoundingClientRect())
+              onInspectCharacter(entity.id)
             }}
-          />
-        )}
-      </div>
+          >
+            {t('portrait.inspect')}
+          </ContextMenuItem>
+          {isGM &&
+            (visibilityMap.get(entity.id) ?? true) &&
+            activeSceneId &&
+            sceneIdSet.has(entity.id) && (
+              <ContextMenuItem
+                onSelect={() => {
+                  if (activeSceneId) void toggleEntityVisibility(activeSceneId, entity.id, false)
+                }}
+              >
+                {t('portrait.off_stage')}
+              </ContextMenuItem>
+            )}
+          {isGM && (
+            <ContextMenuItem
+              onSelect={() => {
+                void saveEntityAsBlueprint(entity)
+              }}
+            >
+              {t('portrait.save_as_blueprint')}
+            </ContextMenuItem>
+          )}
+          {isGM && entity.lifecycle === 'ephemeral' && (
+            <ContextMenuItem
+              onSelect={() => {
+                void updateEntity(entity.id, { lifecycle: 'reusable' })
+              }}
+            >
+              {t('portrait.save_as_character')}
+            </ContextMenuItem>
+          )}
+          {isGM && entity.lifecycle !== 'persistent' && (
+            <ContextMenuItem
+              variant="danger"
+              onSelect={() => {
+                onRemoveFromScene(entity.id)
+              }}
+            >
+              {t('portrait.remove')}
+            </ContextMenuItem>
+          )}
+        </ContextMenuContent>
+      </ContextMenu.Root>
     )
   }
 
@@ -611,24 +605,6 @@ export function PortraitBar({
           </span>
         </div>
       )}
-
-      {/* Context menu — rendered via portal to avoid transform offset */}
-      {contextMenu &&
-        (() => {
-          const entity = visibleEntities.find((e) => e.id === contextMenu.entityId)
-          if (!entity) return null
-          return createPortal(
-            <ContextMenu
-              x={contextMenu.x}
-              y={contextMenu.y}
-              items={getContextMenuItems(entity)}
-              onClose={() => {
-                setContextMenu(null)
-              }}
-            />,
-            document.body,
-          )
-        })()}
 
       {/* Entity popover — rendered via portal */}
       {popoverEntity &&


### PR DESCRIPTION
## Summary

- Migrate 3 files from self-built `ContextMenu` component to Radix `ContextMenu.Root/Trigger/Content`
- Replace imperative item arrays (`getContextMenuItems()`) with declarative JSX (`<ContextMenuItem>`)
- Remove manual coordinate state, event handlers, and `createPortal` rendering
- Net reduction: -108 lines (399 added, 468 removed, including Prettier reformatting)

## Files changed

| File | What changed |
|------|-------------|
| `PortraitBar.tsx` | Each portrait wrapped with `ContextMenu.Root/Trigger`; GM-conditional items rendered inline |
| `BlueprintDockTab.tsx` | Each blueprint card wrapped; spawn/add/edit-tags/delete items inline |
| `MapDockTab.tsx` | Each gallery asset wrapped; set-bg/set-tactical/showcase/delete items inline |

**Note**: App.tsx background context menu deferred to PR E (intertwined with Konva tactical panel events).

## Test plan

- [x] `pnpm tsc -b` — no TypeScript errors
- [x] `pnpm vitest run` — 777 tests passing
- [x] `npx playwright test` — 50/50 e2e passing (ctx-set-bg, ctx-delete, ctx-spawn-on-map, ctx-add-as-npc, ctx-delete-blueprint all verified)