### PR TITLE
feat: migrate confirm popovers and click-outside to Radix primitives

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,8 @@ import { SceneButton } from './gm/SceneButton'
 import { HamburgerMenu } from './layout/HamburgerMenu'
 import { PortraitBar } from './layout/PortraitBar'
 import { MyCharacterCard } from './layout/MyCharacterCard'
-import { ContextMenu } from './shared/ContextMenu'
+import * as Popover from '@radix-ui/react-popover'
+import { PopoverContent } from './ui/primitives/PopoverContent'
 import { ShowcaseOverlay } from './showcase/ShowcaseOverlay'
 import type { ShowcaseItem } from './shared/showcaseTypes'
 import type { Entity, Atmosphere, SceneEntityEntry } from './shared/entityTypes'
@@ -517,16 +518,33 @@ function RoomSession({ roomId }: { roomId: string }) {
         )}
 
         {/* Background right-click context menu (GM only) */}
-        {bgContextMenu && (
-          <ContextMenu
-            x={bgContextMenu.x}
-            y={bgContextMenu.y}
-            items={[{ label: t('add_npc'), onClick: handleAddNpc }]}
-            onClose={() => {
-              setBgContextMenu(null)
+        <Popover.Root
+          open={bgContextMenu !== null}
+          onOpenChange={(open) => {
+            if (!open) setBgContextMenu(null)
+          }}
+        >
+          <Popover.Anchor
+            className="fixed pointer-events-none w-0 h-0"
+            style={{
+              left: bgContextMenu?.x ?? 0,
+              top: bgContextMenu?.y ?? 0,
             }}
           />
-        )}
+          <PopoverContent
+            side="bottom"
+            align="start"
+            sideOffset={0}
+            className="min-w-[160px] rounded-lg bg-glass py-1 backdrop-blur-[16px] px-0"
+          >
+            <button
+              onClick={handleAddNpc}
+              className="block w-full px-3.5 py-2 bg-transparent border-none text-xs font-medium text-left font-sans transition-colors duration-100 cursor-pointer hover:bg-hover text-text-primary"
+            >
+              {t('add_npc')}
+            </button>
+          </PopoverContent>
+        </Popover.Root>
 
         {editingHandout && (
           <HandoutEditModal

--- a/src/combat/TokenContextMenu.tsx
+++ b/src/combat/TokenContextMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { MapToken, Entity } from '../shared/entityTypes'
+import { useClickOutside } from '../hooks/useClickOutside'
 
 interface TokenContextMenuProps {
   x: number
@@ -40,18 +41,8 @@ export function TokenContextMenu({
   const { t } = useTranslation('combat')
   const ref = useRef<HTMLDivElement>(null)
 
-  // Click-outside-to-close
-  useEffect(() => {
-    const handlePointerDown = (e: PointerEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose()
-      }
-    }
-    document.addEventListener('pointerdown', handlePointerDown)
-    return () => {
-      document.removeEventListener('pointerdown', handlePointerDown)
-    }
-  }, [onClose])
+  // Click-outside-to-close (Radix Portal-aware)
+  useClickOutside(ref, onClose)
 
   // Escape key to close
   useEffect(() => {
@@ -87,10 +78,7 @@ export function TokenContextMenu({
       {isTokenMenu ? (
         <>
           {/* Header: token name */}
-          <div
-            className="px-3 py-1.5 text-text-muted text-xs font-medium border-b border-border-glass mb-1"
-            style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
-          >
+          <div className="px-3 py-1.5 text-text-muted text-xs font-medium border-b border-border-glass mb-1 whitespace-nowrap overflow-hidden text-ellipsis">
             {tokenName}
           </div>
 
@@ -107,7 +95,7 @@ export function TokenContextMenu({
           <div className="border-t border-border-glass my-1" />
 
           {/* Size submenu — radio style */}
-          <div className="px-3 py-1 text-text-muted" style={{ fontSize: 10, fontWeight: 600 }}>
+          <div className="px-3 py-1 text-text-muted text-[10px] font-semibold">
             {t('token.size')}
           </div>
           <div className="flex gap-1 px-3 py-1">
@@ -118,15 +106,11 @@ export function TokenContextMenu({
                   onUpdateToken(tokenId, { width: s, height: s })
                   onClose()
                 }}
-                className="border-none cursor-pointer rounded text-xs font-bold transition-colors duration-100"
-                style={{
-                  width: 28,
-                  height: 24,
-                  background: s === currentSize ? 'rgba(212,160,85,0.3)' : 'transparent',
-                  color: s === currentSize ? '#D4A055' : '#F0E6D8',
-                  border:
-                    s === currentSize ? '1px solid rgba(212,160,85,0.5)' : '1px solid transparent',
-                }}
+                className={`w-7 h-6 border cursor-pointer rounded text-xs font-bold transition-colors duration-100 ${
+                  s === currentSize
+                    ? 'bg-accent/30 text-accent border-accent/50'
+                    : 'bg-transparent text-text-primary border-transparent'
+                }`}
               >
                 {s}
               </button>
@@ -191,10 +175,9 @@ function MenuItem({
   return (
     <button
       onClick={onClick}
-      className="block w-full px-3 py-1.5 bg-transparent border-none text-xs font-medium text-left font-sans transition-colors duration-100 cursor-pointer hover:bg-hover"
-      style={{
-        color: danger ? '#C04040' : '#F0E6D8',
-      }}
+      className={`block w-full px-3 py-1.5 bg-transparent border-none text-xs font-medium text-left font-sans transition-colors duration-100 cursor-pointer hover:bg-hover ${
+        danger ? 'text-danger' : 'text-text-primary'
+      }`}
     >
       {label}
     </button>

--- a/src/gm/ArchivePanel.tsx
+++ b/src/gm/ArchivePanel.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState, useRef, useMemo } from 'react'
 import { Plus, Download, Save, MoreVertical, Copy, Pencil, Trash2, Swords } from 'lucide-react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import * as Popover from '@radix-ui/react-popover'
 import { useWorldStore } from '../stores/worldStore'
 import type { ArchiveRecord } from '../stores/worldStore'
 import { selectIsTactical } from '../stores/selectors'
 import { useToast } from '../ui/useToast'
-import { ConfirmPopover } from '../ui/ConfirmPopover'
+import { DropdownMenuContent } from '../ui/primitives/DropdownMenuContent'
+import { DropdownMenuItem } from '../ui/primitives/DropdownMenuItem'
+import { ConfirmDropdownItem } from '../ui/ConfirmDropdownItem'
+import { PopoverContent } from '../ui/primitives/PopoverContent'
 import { useTranslation } from 'react-i18next'
 
 export function ArchivePanel() {
@@ -23,16 +28,11 @@ export function ArchivePanel() {
   const { toast } = useToast()
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [menuId, setMenuId] = useState<string | null>(null)
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
-  const [deletingId, setDeletingId] = useState<string | null>(null)
   const [loadingId, setLoadingId] = useState<string | null>(null)
 
   const renameInputRef = useRef<HTMLInputElement>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
-  const deleteButtonRef = useRef<HTMLButtonElement>(null)
-  const loadButtonRef = useRef<HTMLButtonElement>(null)
 
   // Fetch archives when scene changes
   useEffect(() => {
@@ -45,20 +45,6 @@ export function ArchivePanel() {
   useEffect(() => {
     if (renamingId) renameInputRef.current?.focus()
   }, [renamingId])
-
-  // Close menu on click outside
-  useEffect(() => {
-    if (!menuId) return
-    const handler = (e: PointerEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuId(null)
-      }
-    }
-    document.addEventListener('pointerdown', handler)
-    return () => {
-      document.removeEventListener('pointerdown', handler)
-    }
-  }, [menuId])
 
   const sortedArchives = useMemo(
     () => [...archives].sort((a, b) => a.name.localeCompare(b.name)),
@@ -85,8 +71,6 @@ export function ArchivePanel() {
   }
 
   const handleDelete = (archive: ArchiveRecord) => {
-    setDeletingId(null)
-    setMenuId(null)
     // Optimistic removal from local state, delete on server
     void deleteArchive(archive.id)
     toast('undo', t('archive.deleted', { name: archive.name }), {
@@ -109,7 +93,6 @@ export function ArchivePanel() {
   }
 
   const selectedArchive = selectedId ? archives.find((e) => e.id === selectedId) : null
-  const deletingArchive = deletingId ? archives.find((e) => e.id === deletingId) : null
   const loadingArchive = loadingId ? archives.find((e) => e.id === loadingId) : null
 
   if (!activeSceneId) {
@@ -177,65 +160,49 @@ export function ArchivePanel() {
                       <span className="text-[10px] text-text-muted/50 shrink-0">🗺</span>
                     )}
 
-                    {/* Context menu button */}
-                    <button
-                      ref={deletingId === archive.id ? deleteButtonRef : undefined}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setMenuId(menuId === archive.id ? null : archive.id)
-                      }}
-                      className="opacity-0 group-hover:opacity-100 text-text-muted/40 hover:text-text-primary p-0.5 cursor-pointer transition-opacity duration-fast"
-                    >
-                      <MoreVertical size={12} strokeWidth={1.5} />
-                    </button>
+                    {/* ⋮ Dropdown menu */}
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                          }}
+                          className="opacity-0 group-hover:opacity-100 text-text-muted/40 hover:text-text-primary p-0.5 cursor-pointer transition-opacity duration-fast"
+                        >
+                          <MoreVertical size={12} strokeWidth={1.5} />
+                        </button>
+                      </DropdownMenu.Trigger>
+                      <DropdownMenuContent align="end" sideOffset={4}>
+                        <DropdownMenuItem
+                          onSelect={() => {
+                            setRenamingId(archive.id)
+                            setRenameValue(archive.name)
+                          }}
+                        >
+                          <Pencil size={12} strokeWidth={1.5} />
+                          {t('archive.rename')}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => {
+                            void duplicateArchive(archive.id)
+                          }}
+                        >
+                          <Copy size={12} strokeWidth={1.5} />
+                          {t('archive.duplicate')}
+                        </DropdownMenuItem>
+                        <DropdownMenu.Separator className="border-t border-border-glass my-1" />
+                        <ConfirmDropdownItem
+                          icon={<Trash2 size={12} strokeWidth={1.5} />}
+                          message={t('archive.delete_confirm', { name: archive.name })}
+                          onConfirm={() => {
+                            handleDelete(archive)
+                          }}
+                        >
+                          Delete
+                        </ConfirmDropdownItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu.Root>
                   </div>
-
-                  {/* Context menu dropdown */}
-                  {menuId === archive.id && (
-                    <div
-                      ref={menuRef}
-                      className="absolute right-1 top-full mt-0.5 z-popover bg-surface border border-border-glass rounded-md shadow-lg py-1 min-w-[120px]"
-                      onPointerDown={(e) => {
-                        e.stopPropagation()
-                      }}
-                    >
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setRenamingId(archive.id)
-                          setRenameValue(archive.name)
-                          setMenuId(null)
-                        }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-text-primary hover:bg-hover cursor-pointer transition-colors duration-fast"
-                      >
-                        <Pencil size={12} strokeWidth={1.5} />
-                        {t('archive.rename')}
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          void duplicateArchive(archive.id)
-                          setMenuId(null)
-                        }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-text-primary hover:bg-hover cursor-pointer transition-colors duration-fast"
-                      >
-                        <Copy size={12} strokeWidth={1.5} />
-                        {t('archive.duplicate')}
-                      </button>
-                      <div className="border-t border-border-glass my-1" />
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setDeletingId(archive.id)
-                          setMenuId(null)
-                        }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-danger hover:bg-hover cursor-pointer transition-colors duration-fast"
-                      >
-                        <Trash2 size={12} strokeWidth={1.5} />
-                        Delete
-                      </button>
-                    </div>
-                  )}
                 </div>
               )
             })}
@@ -275,50 +242,53 @@ export function ArchivePanel() {
 
         {/* Load from selected archive (with confirmation) */}
         {selectedArchive && (
-          <button
-            data-testid="archive-load"
-            ref={loadButtonRef}
-            onClick={() => {
-              setLoadingId(selectedId)
+          <Popover.Root
+            open={loadingId !== null}
+            onOpenChange={(open) => {
+              if (!open) setLoadingId(null)
             }}
-            className="flex items-center gap-1 text-[11px] text-white bg-accent/80 hover:bg-accent px-2.5 py-1 rounded cursor-pointer transition-colors duration-fast"
-            title={t('archive.load_title')}
           >
-            <Download size={14} strokeWidth={1.5} />
-            {t('archive.load')}
-          </button>
+            <Popover.Trigger asChild>
+              <button
+                data-testid="archive-load"
+                onClick={() => {
+                  setLoadingId(selectedId)
+                }}
+                className="flex items-center gap-1 text-[11px] text-white bg-accent/80 hover:bg-accent px-2.5 py-1 rounded cursor-pointer transition-colors duration-fast"
+                title={t('archive.load_title')}
+              >
+                <Download size={14} strokeWidth={1.5} />
+                {t('archive.load')}
+              </button>
+            </Popover.Trigger>
+            {loadingArchive && (
+              <PopoverContent side="top" align="center" className="min-w-[140px]">
+                <p className="text-xs text-text-primary mb-2.5 whitespace-nowrap">
+                  {t('archive.load_confirm', { name: loadingArchive.name })}
+                </p>
+                <div className="flex justify-end gap-2">
+                  <button
+                    data-testid="confirm-cancel"
+                    onClick={() => {
+                      setLoadingId(null)
+                    }}
+                    className="text-[11px] text-text-muted px-2 py-1 rounded hover:bg-hover cursor-pointer transition-colors duration-fast"
+                  >
+                    {t('cancel', { ns: 'ui' })}
+                  </button>
+                  <button
+                    data-testid="confirm-action"
+                    onClick={handleLoad}
+                    className="text-[11px] text-white bg-danger px-2.5 py-1 rounded hover:bg-danger/80 cursor-pointer transition-colors duration-fast"
+                  >
+                    {t('confirm_default', { ns: 'ui' })}
+                  </button>
+                </div>
+              </PopoverContent>
+            )}
+          </Popover.Root>
         )}
       </div>
-
-      {/* Delete confirmation popover */}
-      {deletingArchive && (
-        <ConfirmPopover
-          anchorRef={deleteButtonRef}
-          message={t('archive.delete_confirm', { name: deletingArchive.name })}
-          confirmLabel="Delete"
-          cancelLabel="Cancel"
-          onConfirm={() => {
-            handleDelete(deletingArchive)
-          }}
-          onCancel={() => {
-            setDeletingId(null)
-          }}
-        />
-      )}
-
-      {/* Load confirmation popover */}
-      {loadingArchive && (
-        <ConfirmPopover
-          anchorRef={loadButtonRef}
-          message={t('archive.load_confirm', { name: loadingArchive.name })}
-          confirmLabel="Confirm"
-          cancelLabel="Cancel"
-          onConfirm={handleLoad}
-          onCancel={() => {
-            setLoadingId(null)
-          }}
-        />
-      )}
     </div>
   )
 }

--- a/src/gm/GmDock.tsx
+++ b/src/gm/GmDock.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   FolderOpen,
@@ -18,6 +18,7 @@ import { useToast } from '../ui/useToast'
 import { defaultNPCPermissions } from '../shared/permissions'
 import { useWorldStore } from '../stores/worldStore'
 import { useUiStore } from '../stores/uiStore'
+import { useClickOutside } from '../hooks/useClickOutside'
 import { MapDockTab } from '../dock/MapDockTab'
 import { BlueprintDockTab } from '../dock/BlueprintDockTab'
 import { HandoutDockTab } from '../dock/HandoutDockTab'
@@ -90,19 +91,11 @@ export function GmDock({
     }
   }, [activeTab, collapsed])
 
-  // Click outside to collapse
-  useEffect(() => {
-    if (activeTab === null) return
-    const handleClickOutside = (e: PointerEvent) => {
-      if (dockRef.current && !dockRef.current.contains(e.target as Node)) {
-        setActiveTab(null)
-      }
-    }
-    document.addEventListener('pointerdown', handleClickOutside)
-    return () => {
-      document.removeEventListener('pointerdown', handleClickOutside)
-    }
-  }, [activeTab, setActiveTab])
+  // Click outside to collapse (Radix Portal-aware)
+  const handleClickOutside = useCallback(() => {
+    setActiveTab(null)
+  }, [setActiveTab])
+  useClickOutside(dockRef, handleClickOutside, activeTab !== null)
 
   const toggleTab = (tab: GmDockTab) => {
     setActiveTab(activeTab === tab ? null : tab)

--- a/src/gm/SceneListPanel.tsx
+++ b/src/gm/SceneListPanel.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { X, Copy, Plus, Trash2 } from 'lucide-react'
+import * as Popover from '@radix-ui/react-popover'
 import type { Scene } from '../stores/worldStore'
 import { isVideoUrl } from '../shared/assetUpload'
-import { ConfirmPopover } from '../ui/ConfirmPopover'
+import { PopoverContent } from '../ui/primitives/PopoverContent'
+import { useClickOutside } from '../hooks/useClickOutside'
 
 interface SceneListPanelProps {
   scenes: Scene[]
@@ -32,20 +34,9 @@ export function SceneListPanel({
   const [renameValue, setRenameValue] = useState('')
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
-  const deleteButtonRef = useRef<HTMLButtonElement>(null)
 
-  // Click-outside-to-close
-  useEffect(() => {
-    const handler = (e: PointerEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
-        onClose()
-      }
-    }
-    document.addEventListener('pointerdown', handler)
-    return () => {
-      document.removeEventListener('pointerdown', handler)
-    }
-  }, [onClose])
+  // Click-outside-to-close (Radix Portal-aware)
+  useClickOutside(panelRef, onClose)
 
   // Auto-focus rename input
   useEffect(() => {
@@ -58,8 +49,6 @@ export function SceneListPanel({
     }
     setRenamingId(null)
   }
-
-  const deletingScene = deletingId ? scenes.find((s) => s.id === deletingId) : null
 
   return (
     <div
@@ -168,17 +157,53 @@ export function SceneListPanel({
                       <Copy size={12} strokeWidth={1.5} />
                     </button>
                     {scenes.length > 1 && (
-                      <button
-                        ref={deletingId === scene.id ? deleteButtonRef : undefined}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setDeletingId(scene.id)
+                      <Popover.Root
+                        open={deletingId === scene.id}
+                        onOpenChange={(open) => {
+                          if (!open) setDeletingId(null)
                         }}
-                        className="opacity-0 group-hover:opacity-100 text-white/50 hover:text-danger transition-all duration-fast p-1 cursor-pointer"
-                        title={t('scene.delete')}
                       >
-                        <Trash2 size={12} strokeWidth={1.5} />
-                      </button>
+                        <Popover.Trigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              setDeletingId(scene.id)
+                            }}
+                            className="opacity-0 group-hover:opacity-100 text-white/50 hover:text-danger transition-all duration-fast p-1 cursor-pointer"
+                            title={t('scene.delete')}
+                          >
+                            <Trash2 size={12} strokeWidth={1.5} />
+                          </button>
+                        </Popover.Trigger>
+                        <PopoverContent side="top" align="center" className="min-w-[140px]">
+                          <p className="text-xs text-text-primary mb-2.5 whitespace-nowrap">
+                            {t('archive.delete_confirm', {
+                              name: scene.name || t('scene.untitled'),
+                            })}
+                          </p>
+                          <div className="flex justify-end gap-2">
+                            <button
+                              data-testid="confirm-cancel"
+                              onClick={() => {
+                                setDeletingId(null)
+                              }}
+                              className="text-[11px] text-text-muted px-2 py-1 rounded hover:bg-hover cursor-pointer transition-colors duration-fast"
+                            >
+                              {t('cancel', { ns: 'ui' })}
+                            </button>
+                            <button
+                              data-testid="confirm-action"
+                              onClick={() => {
+                                onDeleteScene(scene.id)
+                                setDeletingId(null)
+                              }}
+                              className="text-[11px] text-white bg-danger px-2.5 py-1 rounded hover:bg-danger/80 cursor-pointer transition-colors duration-fast"
+                            >
+                              {t('delete_default', { ns: 'ui' })}
+                            </button>
+                          </div>
+                        </PopoverContent>
+                      </Popover.Root>
                     )}
                   </div>
                 </div>
@@ -197,21 +222,6 @@ export function SceneListPanel({
           </div>
         </div>
       </div>
-
-      {/* Delete confirmation popover */}
-      {deletingScene && (
-        <ConfirmPopover
-          anchorRef={deleteButtonRef}
-          message={t('archive.delete_confirm', { name: deletingScene.name || t('scene.untitled') })}
-          onConfirm={() => {
-            onDeleteScene(deletingScene.id)
-            setDeletingId(null)
-          }}
-          onCancel={() => {
-            setDeletingId(null)
-          }}
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **SceneListPanel**: Replace `ConfirmPopover` with Radix `Popover` for scene delete confirmation; replace hand-built click-outside with `useClickOutside` hook
- **ArchivePanel**: Replace ⋮ hand-built dropdown with Radix `DropdownMenu` + `ConfirmDropdownItem` for delete; replace load `ConfirmPopover` with Radix `Popover`
- **App.tsx**: Replace `shared/ContextMenu` background right-click menu with Radix `Popover` using fixed-position virtual anchor
- **GmDock**: Replace hand-built click-outside handler with `useClickOutside` hook (Radix Portal-aware)
- **TokenContextMenu**: Replace hand-built click-outside with `useClickOutside`; replace hardcoded hex colors (`#D4A055`, `#F0E6D8`, `#C04040`) with Tailwind design tokens (`text-accent`, `text-text-primary`, `text-danger`)

Net: -214 lines removed, +188 lines added (−26 lines)

## Test plan
- [x] `tsc -b` — zero TypeScript errors
- [x] `vitest run` — 777/777 tests pass
- [x] `eslint` — no lint errors on changed files
- [x] `playwright test` — 50/50 e2e tests pass
- [x] Production build succeeds
- [ ] Manual: right-click scene delete → confirm popover appears above button
- [ ] Manual: archive ⋮ menu → rename, duplicate, delete (with confirm) work
- [ ] Manual: archive load → confirm popover appears above load button
- [ ] Manual: right-click empty scene/tactical background → "Add NPC" appears at cursor
- [ ] Manual: GmDock click-outside closes dock; clicking inside Radix popovers does NOT close dock