### PR TITLE
chore: add issue linking convention to PR template and git workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,10 @@
 
 <!-- Brief description of the change -->
 
-## Closes
+## Related Issues
 
-<!-- Link related issues so they auto-close on merge. Delete this section if no related issue. -->
+<!-- Every PR must link at least one issue (CI enforced).
+     Use "Closes #N" to auto-close on merge, or "Part of #N" for incremental progress. -->
 
 - Closes #
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -36,3 +36,14 @@ jobs:
             echo "::error::PR body contains an AI-generated signature line. Please remove it."
             exit 1
           fi
+
+      - name: Check issue linking
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if echo "$BODY" | grep -qiE '(closes|part of) #[0-9]+'; then
+            echo "Issue reference found."
+          else
+            echo "::error::PR body must reference an issue. Use 'Closes #N' to auto-close, or 'Part of #N' for incremental progress."
+            exit 1
+          fi

--- a/docs/conventions/git-workflow.md
+++ b/docs/conventions/git-workflow.md
@@ -51,9 +51,12 @@ native module resolution and produces spurious test failures unrelated to your c
 
 ## Issue Linking
 
-- Every PR that resolves an issue **must** include `Closes #N` in the PR body (the template has a dedicated section)
-- GitHub will auto-close the linked issue when the PR is squash-merged into main
+- Every PR **must** reference at least one issue in its body
+- Use `Closes #N` when the PR fully resolves an issue (GitHub auto-closes it on merge)
+- Use `Part of #N` when the PR is incremental progress toward a larger issue
+- For large issues: split into sub-issues with a tracking issue using task lists, or use `Part of` for intermediate PRs
 - Use `Closes` (not `Fixes` or `Resolves`) for consistency
+- CI enforces this — PRs without `Closes #N` or `Part of #N` will fail the check
 
 ## Merge Flow
 


### PR DESCRIPTION
## Summary

- Add `## Related Issues` section to PR template so authors are prompted to link issues
- Add `## Issue Linking` section to git-workflow.md convention doc
- Add CI check in pr-title.yml that enforces `Closes #N` or `Part of #N` in PR body
- Standardize on `Closes #N` keyword for auto-closing issues on merge

## Related Issues

- Closes #143

## Test Plan

- N/A (documentation and CI config change)