### PR TITLE
feat: preview CLI enhancements — tab title, readiness output

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
       - VITE_DEV_PORT=5173
       - VITE_PROXY_MODE=${VITE_PROXY_MODE:-}
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:5173}
+      - VITE_PREVIEW_BRANCH=${VITE_PREVIEW_BRANCH:-}
 
 volumes:
   vtt-data:

--- a/scripts/preview-cli.ts
+++ b/scripts/preview-cli.ts
@@ -4,6 +4,7 @@
 
 import { execSync, spawn, type ChildProcess } from 'child_process'
 import { existsSync } from 'fs'
+import { get } from 'http'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -163,6 +164,41 @@ function bold(msg: string): string {
   return `\x1b[1m${msg}\x1b[0m`
 }
 
+/** Poll a port until it responds to HTTP, then call the callback */
+function waitForReady(port: number, onReady: () => void): { cancel: () => void } {
+  const MAX_ATTEMPTS = 100
+  const INTERVAL_MS = 3000
+  let attempts = 0
+  let cancelled = false
+  let resolved = false
+
+  const timer = setInterval(() => {
+    if (cancelled || resolved) return
+    attempts++
+    if (attempts > MAX_ATTEMPTS) {
+      clearInterval(timer)
+      return
+    }
+    const req = get(`http://localhost:${port}`, () => {
+      if (resolved) return
+      resolved = true
+      clearInterval(timer)
+      if (!cancelled) onReady()
+    })
+    req.on('error', () => {
+      // Not ready yet, will retry
+    })
+    req.setTimeout(2000, () => req.destroy())
+  }, INTERVAL_MS)
+
+  return {
+    cancel: () => {
+      cancelled = true
+      clearInterval(timer)
+    },
+  }
+}
+
 // ── Commands ──
 
 function cmdStart(branch: string) {
@@ -192,6 +228,7 @@ function cmdStart(branch: string) {
     HOST_VITE_PORT: String(vitePort),
     VITE_PROXY_MODE: 'true',
     CORS_ORIGIN: `http://localhost:${vitePort}`,
+    VITE_PREVIEW_BRANCH: branch,
   }
 
   log('')
@@ -220,11 +257,21 @@ function cmdStart(branch: string) {
     },
   )
 
+  // Poll for container readiness and print final port summary
+  const readyPoller = waitForReady(vitePort, () => {
+    log('')
+    log(`\x1b[32m✔ Preview ready\x1b[0m`)
+    log(`  UI:  http://localhost:${vitePort}`)
+    log(`  API: http://localhost:${serverPort}`)
+    log('')
+  })
+
   // Guard against double cleanup (SIGINT handler + child exit can both fire)
   let cleanedUp = false
   const cleanup = () => {
     if (cleanedUp) return
     cleanedUp = true
+    readyPoller.cancel()
     log('')
     log(`Shutting down preview for '${branch}'...`)
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,10 @@ import './lib/devBridge'
 import './styles/global.css'
 import App from './App'
 
+// In preview mode, show branch name in tab title for multi-branch identification
+const previewBranch = import.meta.env.VITE_PREVIEW_BRANCH
+if (previewBranch) document.title = `myVTT [${previewBranch}]`
+
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
     <Suspense fallback={null}>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_SERVER_PORT: string
   readonly VITE_PROXY_MODE: string
+  readonly VITE_PREVIEW_BRANCH?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Show branch name in browser tab title (`myVTT [branch-name]`) for multi-branch identification
- Print port summary (`✔ Preview ready` + UI/API URLs) after container is ready, at the bottom of output for automation-friendly workflows
- Add `VITE_PREVIEW_BRANCH` to TypeScript env type declaration

Part of #103

## Test plan
- [x] Start preview, verify `✔ Preview ready` with ports appears after Docker build logs
- [x] Verify `VITE_PREVIEW_BRANCH` is injected into Vite client bundle
- [x] Verify `document.title` is set to `myVTT [feat/preview-enhancements]` in browser
- [x] Verify main worktree support already works (no code change needed)
- [x] All 947 tests pass, build succeeds